### PR TITLE
Fix goroutine leak in `AuthenticateBasicToken`

### DIFF
--- a/client.go
+++ b/client.go
@@ -163,9 +163,9 @@ func (c *SpiceClient) queryInternal(ctx context.Context, client flight.Client, a
 		return nil, fmt.Errorf("flight client is not initialized")
 	}
 
-	streamCtx, cancel := context.WithCancel(ctx)
+	tokenCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	authContext, err := client.AuthenticateBasicToken(streamCtx, appId, apiKey)
+	authContext, err := client.AuthenticateBasicToken(tokenCtx, appId, apiKey)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -163,7 +163,9 @@ func (c *SpiceClient) queryInternal(ctx context.Context, client flight.Client, a
 		return nil, fmt.Errorf("flight client is not initialized")
 	}
 
-	authContext, err := client.AuthenticateBasicToken(ctx, appId, apiKey)
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	authContext, err := client.AuthenticateBasicToken(streamCtx, appId, apiKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a bug in Arrow's Flight client implementation, but we can workaround it with this PR.

The issue is that `Handshake` is defined as a two-way (i.e. not unary) stream and the GRPC Go library indicates that resources will be leaked if certain conditions are not met. `Handshake` calls `NewStream` in the GRPC library.

```go
// NewStream creates a new Stream for the client side. This is typically
// called by generated code. ctx is used for the lifetime of the stream.
//
// To ensure resources are not leaked due to the stream returned, one of the following
// actions must be performed:
//
//  1. Call Close on the ClientConn.
//  2. Cancel the context provided.
//  3. Call RecvMsg until a non-nil error is returned. A protobuf-generated
//     client-streaming RPC, for instance, might use the helper function
//     CloseAndRecv (note that CloseSend does not Recv, therefore is not
//     guaranteed to release all resources).
//  4. Receive a non-nil, non-io.EOF error from Header or SendMsg.
//
// If none of the above happen, a goroutine and a context will be leaked, and grpc
// will not call the optionally-configured stats handler with a stats.End message.
```

The issue is that in `AuthenticateBasicToken` in the Arrow Flight client, it is possible to not activate any of the above 4 conditions. 
1. `ClientConn.Close()` is not called until the client calls `Close()` on the flight client itself.
2. If the context is `context.Background()` - it will never be cancelled.
3. This is where it *should* handle it and cause the goroutine to get cleaned up. `AuthenticateBasicToken` only calls `stream.Recv()` once - it should call it until it gets a non-nil EOF error. There is another helper method in this package `ReadUntilEOF` which does exactly that, but for a different flight call. The correct fix would be to call `ReadUntilEOF` on this handshake stream.
4. This is an error case that shouldn't normally happen

We can manually activate condition 2 by creating a new context and deferring its cancellation before calling `AuthenticateBasicToken`