### PR TITLE
Revert "Fix goroutine leak in `AuthenticateBasicToken` (#37)"

### DIFF
--- a/client.go
+++ b/client.go
@@ -163,9 +163,7 @@ func (c *SpiceClient) queryInternal(ctx context.Context, client flight.Client, a
 		return nil, fmt.Errorf("flight client is not initialized")
 	}
 
-	tokenCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	authContext, err := client.AuthenticateBasicToken(tokenCtx, appId, apiKey)
+	authContext, err := client.AuthenticateBasicToken(ctx, appId, apiKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This reverts commit d82d9b7698481ca221241c4e1e641affff6cf0db.

Adding a context here causes it to cancel once `queryInternal` finishes - which causes queries which take longer to process to return 0 results.