### PR TITLE
Don't retry ResourceExhausted and Cancelled errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,12 @@ See [client_test.go](client_test.go) for examples on querying Ethereum and Polyg
 ### Configuring retry policy
 
 The `SpiceClient` implements connection retrying mechanism (3 attemps by default).
-This could be configured or disabled using `setMaxRetries`:
+The number of attempts can be configured via `NewSpiceClient`:
 
 ```go
 spice := NewSpiceClient()
 spice.SetMaxRetries(5) // Setting to 0 will disable retries
 ```
 
-Note: Retries are automatically performed for connection and system internal errors. However, it is the responsibility of
-the SDK user to properly handle errors such as RESOURCE_EXHAUSTED or similar. This error indicates that the user's quota has
-been reached, and it may be necessary to decide whether to retry the request later or to add a throttling mechanism.
+Retries are performed for connection and system internal errors. It is the SDK user's responsibility to properly
+handle other errors, for example RESOURCE_EXHAUSTED (HTTP 429).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ go get github.com/spiceai/gospice/v4.0.1
 1. Import the package.
 
 ```go
-import "github.com/spiceai/gospice/v4.0.1"
+import "github.com/spiceai/gospice/v4"
 ```
 
 1. Create a SpiceClient passing in your API key. Get your free API key at [spice.ai](https://spice.ai).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Golang SDK for Spice.ai
 
-See Go Docs at [pkg.go.dev/github.com/spiceai/gospice/v4](https://pkg.go.dev/github.com/spiceai/gospice/v4).
+See Go Docs at [pkg.go.dev/github.com/spiceai/gospice/v4.0.1](https://pkg.go.dev/github.com/spiceai/gospice/v4.0.1).
 
 For full documentation visit [docs.spice.ai](https://docs.spice.ai/sdks/go).
 
@@ -17,13 +17,13 @@ For full documentation visit [docs.spice.ai](https://docs.spice.ai/sdks/go).
 1. Get the gospice package.
 
 ```go
-go get github.com/spiceai/gospice/v4
+go get github.com/spiceai/gospice/v4.0.1
 ```
 
 1. Import the package.
 
 ```go
-import "github.com/spiceai/gospice/v4"
+import "github.com/spiceai/gospice/v4.0.1"
 ```
 
 1. Create a SpiceClient passing in your API key. Get your free API key at [spice.ai](https://spice.ai).

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ Run `go run .` to execute a sample query and print the results to the console.
 
 See [client_test.go](client_test.go) for examples on querying Ethereum and Polygon blocks.
 
-### Configuring retry policy
+### Connection retry
 
-The `SpiceClient` implements connection retrying mechanism (3 attemps by default).
-The number of attempts can be configured via `NewSpiceClient`:
+The `SpiceClient` implements connection retry mechanism (3 attemps by default).
+The number of attempts can be configured via `SetMaxRetries`:
 
 ```go
 spice := NewSpiceClient()

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For full documentation visit [docs.spice.ai](https://docs.spice.ai/sdks/go).
 1. Get the gospice package.
 
 ```go
-go get github.com/spiceai/gospice/v4.0.1
+go get github.com/spiceai/gospice/v4
 ```
 
 1. Import the package.

--- a/README.md
+++ b/README.md
@@ -66,3 +66,17 @@ if err := spice.Init("API Key"); err != nil {
 Run `go run .` to execute a sample query and print the results to the console.
 
 See [client_test.go](client_test.go) for examples on querying Ethereum and Polygon blocks.
+
+### Configuring retry policy
+
+The `SpiceClient` implements connection retrying mechanism (3 attemps by default).
+This could be configured or disabled using `setMaxRetries`:
+
+```go
+spice := NewSpiceClient()
+spice.SetMaxRetries(5) // Setting to 0 will disable retries
+```
+
+Note: Retries are automatically performed for connection and system internal errors. However, it is the responsibility of
+the SDK user to properly handle errors such as RESOURCE_EXHAUSTED or similar. This error indicates that the user's quota has
+been reached, and it may be necessary to decide whether to retry the request later or to add a throttling mechanism.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See [client_test.go](client_test.go) for examples on querying Ethereum and Polyg
 
 ### Connection retry
 
-The `SpiceClient` implements connection retry mechanism (3 attemps by default).
+The `SpiceClient` implements connection retry mechanism (3 attempts by default).
 The number of attempts can be configured via `SetMaxRetries`:
 
 ```go

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Golang SDK for Spice.ai
 
-See Go Docs at [pkg.go.dev/github.com/spiceai/gospice/v4.0.1](https://pkg.go.dev/github.com/spiceai/gospice/v4.0.1).
+See Go Docs at [pkg.go.dev/github.com/spiceai/gospice/v4](https://pkg.go.dev/github.com/spiceai/gospice/v4).
 
 For full documentation visit [docs.spice.ai](https://docs.spice.ai/sdks/go).
 

--- a/client.go
+++ b/client.go
@@ -137,7 +137,7 @@ func (c *SpiceClient) query(ctx context.Context, client flight.Client, appId str
 			st, ok := status.FromError(err)
 			if ok {
 				switch st.Code() {
-				case codes.Canceled, codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted, codes.Internal:
+				case codes.Unavailable, codes.Unknown, codes.DeadlineExceeded, codes.Aborted, codes.Internal:
 					return err
 				}
 				if strings.Contains(err.Error(), "malformed header: missing HTTP content-type") {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	gospice "github.com/spiceai/gospice/v4.0.1"
+	gospice "github.com/spiceai/gospice/v4"
 )
 
 func main() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/spiceai/gospice/v4"
+	gospice "github.com/spiceai/gospice/v4.0.1"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/spiceai/gospice/v4.0.1
+module github.com/spiceai/gospice/v4
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/spiceai/gospice/v4
+module github.com/spiceai/gospice/v4.0.1
 
 go 1.20
 


### PR DESCRIPTION
Note: I've enabled retry additionally for UNKNOWN error as part of this change:

https://chromium.googlesource.com/external/github.com/grpc/grpc/+/refs/tags/v1.21.4-pre1/doc/statuscodes.md

Unknown error. For example, this error may be returned when a Status value received from another address space belongs to an error space that is not known in this address space. Also errors raised by APIs that do not return enough error information may be converted to this error.