### PR TITLE
Update `Init()` with middleware, and added support for local spice runtime

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,5 +26,19 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+      - name: install Spice (https://install.spiceai.org)
+        run: |
+          curl https://install.spiceai.org | /bin/bash
+          echo "$HOME/.spice/bin" >> $GITHUB_PATH
+
+      - name: Init and start spice app
+        run: |
+          spice init spice_qs
+          cd spice_qs
+          spice add spiceai/quickstart
+          spice run &> spice.log &
+          # time to initialize added dataset
+          sleep 10
+
       - name: Test
         run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ if err := spice.Init(
 
 ### Using local spice runtime
 
-Follow the [quiqstart guide](https://github.com/spiceai/spiceai?tab=readme-ov-file#%EF%B8%8F-quickstart-local-machine) to install and run spice locally
+Follow the [quickstart guide](https://github.com/spiceai/spiceai?tab=readme-ov-file#%EF%B8%8F-quickstart-local-machine) to install and run spice locally
 
 Initialize the SpiceClient to use local runtime connection:
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ spice := NewSpiceClient()
 defer spice.Close()
 ```
 
-1. Initialize the SpiceClient.
+1. Initialize the SpiceClient with spice.ai cloud.
 
 ```go
-if err := spice.Init("API Key"); err != nil {
+if err := spice.Init(
+    spice.WithApiKey(ApiKey),
+    spice.WithSpiceCloudAddress()
+); err != nil {
     panic(fmt.Errorf("error initializing SpiceClient: %w", err))
 }
 ```
@@ -53,6 +56,28 @@ if err := spice.Init("API Key"); err != nil {
         defer record.Release()
         fmt.Println(record)
     }
+```
+
+### Using local spice runtime
+
+Follow the [quiqstart guide](https://github.com/spiceai/spiceai?tab=readme-ov-file#%EF%B8%8F-quickstart-local-machine) to install and run spice locally
+
+Initialize the SpiceClient to use local runtime connection:
+
+```go
+if err := spice.Init(); err != nil {
+    panic(fmt.Errorf("error initializing SpiceClient: %w", err))
+}
+```
+
+Configure with a custom flight address:
+
+```go
+if err := spice.Init(
+    spice.WithFlightAddress("grpc://localhost:50052")
+); err != nil {
+    panic(fmt.Errorf("error initializing SpiceClient: %w", err))
+}
 ```
 
 ## Example

--- a/client.go
+++ b/client.go
@@ -23,7 +23,8 @@ const (
 	MAX_MESSAGE_SIZE_BYTES = 100 * 1024 * 1024
 )
 
-var defaultConfig = LoadConfig()
+var defaultCloudConfig = LoadConfig()
+var defaultLocalConfig = LoadLocalConfig()
 
 // SpiceClient is a client for Spice.ai - Data and AI infrastructure for web3
 // https://spice.ai
@@ -44,14 +45,14 @@ type SpiceClient struct {
 
 // NewSpiceClient creates a new SpiceClient
 func NewSpiceClient() *SpiceClient {
-	return NewSpiceClientWithAddress(defaultConfig.FlightUrl, defaultConfig.FirecacheUrl)
+	return NewSpiceClientWithAddress(defaultLocalConfig.FlightUrl, defaultLocalConfig.FirecacheUrl)
 }
 
 func NewSpiceClientWithAddress(flightAddress string, firecacheAddress string) *SpiceClient {
 	spiceClient := &SpiceClient{
 		flightAddress:    flightAddress,
 		firecacheAddress: firecacheAddress,
-		baseHttpUrl:      defaultConfig.HttpUrl,
+		baseHttpUrl:      defaultCloudConfig.HttpUrl,
 		httpClient: http.Client{
 			Transport: &http.Transport{
 				MaxIdleConnsPerHost: 10,
@@ -64,14 +65,54 @@ func NewSpiceClientWithAddress(flightAddress string, firecacheAddress string) *S
 	return spiceClient
 }
 
-// Init initializes the SpiceClient
-func (c *SpiceClient) Init(apiKey string) error {
-	if apiKey == "" {
-		return fmt.Errorf("apiKey is required")
+type SpiceClientModifier func(c *SpiceClient) error
+
+func WithApiKey(apiKey string) SpiceClientModifier {
+	return func(c *SpiceClient) error {
+		if apiKey == "" {
+			return fmt.Errorf("apiKey is required")
+		}
+		apiKeyParts := strings.Split(apiKey, "|")
+		if len(apiKeyParts) != 2 {
+			return fmt.Errorf("apiKey is invalid")
+		}
+
+		c.appId = apiKeyParts[0]
+		c.apiKey = apiKey
+
+		return nil
 	}
-	apiKeyParts := strings.Split(apiKey, "|")
-	if len(apiKeyParts) != 2 {
-		return fmt.Errorf("apiKey is invalid")
+}
+
+func WithFlightAddress(address string) SpiceClientModifier {
+	return func(c *SpiceClient) error {
+		c.flightAddress = address
+		return nil
+	}
+}
+
+func WithFirecacheAddress(address string) SpiceClientModifier {
+	return func(c *SpiceClient) error {
+		c.firecacheAddress = address
+		return nil
+	}
+}
+
+func WithSpiceCloudAddress() SpiceClientModifier {
+	return func(c *SpiceClient) error {
+		c.flightAddress = defaultCloudConfig.FlightUrl
+		c.firecacheAddress = defaultCloudConfig.FirecacheUrl
+		return nil
+	}
+}
+
+// Init initializes the SpiceClient
+func (c *SpiceClient) Init(opts ...SpiceClientModifier) error {
+	for _, opt := range opts {
+		err := opt(c)
+		if err != nil {
+			return err
+		}
 	}
 
 	systemCertPool, err := x509.SystemCertPool()
@@ -89,8 +130,6 @@ func (c *SpiceClient) Init(apiKey string) error {
 		return fmt.Errorf("error creating Spice Firecache client: %w", err)
 	}
 
-	c.appId = apiKeyParts[0]
-	c.apiKey = apiKey
 	c.flightClient = flightClient
 	c.firecacheClient = firecacheClient
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,11 +7,14 @@ import (
 	gospice "github.com/spiceai/gospice/v5"
 )
 
-func main() {
+func querySpiceCloud() {
 	spice := gospice.NewSpiceClient()
 	defer spice.Close()
 
-	if err := spice.Init("3437|89d6b41cd0034cd68eea704f5e88779d"); err != nil {
+	if err := spice.Init(
+		gospice.WithApiKey("3437|89d6b41cd0034cd68eea704f5e88779d"),
+		gospice.WithSpiceCloudAddress(),
+	); err != nil {
 		panic(fmt.Errorf("error initializing SpiceClient: %w", err))
 	}
 
@@ -26,4 +29,30 @@ func main() {
 		defer record.Release()
 		fmt.Println(record)
 	}
+}
+
+func querySpiceLocal() {
+	spice := gospice.NewSpiceClient()
+	defer spice.Close()
+
+	if err := spice.Init(); err != nil {
+		panic(fmt.Errorf("error initializing SpiceClient: %w", err))
+	}
+
+	reader, err := spice.Query(context.Background(), "SELECT * FROM taxi_trips LIMIT 10")
+	if err != nil {
+		panic(fmt.Errorf("error querying: %w", err))
+	}
+	defer reader.Release()
+
+	for reader.Next() {
+		record := reader.Record()
+		defer record.Release()
+		fmt.Println(record)
+	}
+}
+
+func main() {
+	querySpiceCloud()
+	querySpiceLocal()
 }

--- a/config.go
+++ b/config.go
@@ -16,6 +16,14 @@ func LoadConfig() ClientConfig {
 	}
 }
 
+func LoadLocalConfig() ClientConfig {
+	return ClientConfig{
+		HttpUrl:      getEnvOrDefault("SPICE_LOCAL_HTTP_URL", "http://localhost:3000"),
+		FlightUrl:    getEnvOrDefault("SPICE_LOCAL_FLIGHT_URL", "grpc://localhost:50051"),
+		FirecacheUrl: getEnvOrDefault("SPICE_FIRECACHE_URL", "firecache.spiceai.io:443"),
+	}
+}
+
 func getEnvOrDefault(key string, defaultValue string) string {
 	if v, exists := os.LookupEnv(key); exists {
 		return v

--- a/firequery_test.go
+++ b/firequery_test.go
@@ -22,7 +22,7 @@ func TestFireQuery(t *testing.T) {
 		ApiKey = TEST_API_KEY
 	}
 
-	if err := spice.Init(ApiKey); err != nil {
+	if err := spice.Init(WithApiKey(ApiKey), WithSpiceCloudAddress()); err != nil {
 		panic(fmt.Errorf("error initializing SpiceClient: %w", err))
 	}
 

--- a/query_test.go
+++ b/query_test.go
@@ -26,7 +26,7 @@ func TestBasicQuery(t *testing.T) {
 		ApiKey = TEST_API_KEY
 	}
 
-	if err := spice.Init(ApiKey); err != nil {
+	if err := spice.Init(WithApiKey(ApiKey), WithSpiceCloudAddress()); err != nil {
 		panic(fmt.Errorf("error initializing SpiceClient: %w", err))
 	}
 
@@ -80,6 +80,30 @@ func TestBasicQuery(t *testing.T) {
 			if len(hash) != 66 {
 				t.Fatalf("Expected hash length 66, got %d", len(hash))
 			}
+		}
+	})
+}
+
+// Requires local spice running. Follow the quickstart https://github.com/spiceai/spiceai.
+
+func TestLocalRuntime(t *testing.T) {
+	spice := NewSpiceClient()
+	defer spice.Close()
+
+	if err := spice.Init(); err != nil {
+		panic(fmt.Errorf("error initializing SpiceClient: %w", err))
+	}
+
+	t.Run("Query Local Dataset", func(t *testing.T) {
+		reader, err := spice.Query(context.Background(), "select * from taxi_trips limit 3;")
+		if err != nil {
+			panic(fmt.Errorf("error querying: %w", err))
+		}
+		defer reader.Release()
+
+		for reader.Next() {
+			record := reader.Record()
+			defer record.Release()
 		}
 	})
 }


### PR DESCRIPTION
closes #45

Updated `spice.Init` to accept optional middleware for more flexible configuration:

- `spice.Init()` - connects to local spice runtime as a default
- `spice.Init(spice.WithFlightAddress("grpc://localhost:50052"))` - connect to custom flight address
- `spice.Init(spice.WithApiKey("API_KEY"), spice.WithSpiceCloudAddress())` - connect to spice.ai cloud