### PR TITLE
Adding custom user-agent to gospice

### DIFF
--- a/client.go
+++ b/client.go
@@ -95,6 +95,13 @@ func WithHttpAddress(address string) SpiceClientModifier {
 	}
 }
 
+func WithUserAgent(userAgent string) SpiceClientModifier {
+	return func(c *SpiceClient) error {
+		c.userAgent = RemoveNonPrintableASCII(userAgent)
+		return nil
+	}
+}
+
 func WithSpiceCloudAddress() SpiceClientModifier {
 	return func(c *SpiceClient) error {
 		c.flightAddress = defaultCloudConfig.FlightUrl
@@ -197,7 +204,7 @@ func (c *SpiceClient) createClient(address string, systemCertPool *x509.CertPool
 			grpc.MaxCallSendMsgSize(MAX_MESSAGE_SIZE_BYTES),
 		),
 		grpc.WithUnaryInterceptor(FlightHeadersInterceptor(map[string]string{
-			"x-spice-user-agent": c.userAgent,
+			"User-Agent": c.userAgent,
 		})),
 	}
 

--- a/client.go
+++ b/client.go
@@ -204,7 +204,7 @@ func (c *SpiceClient) createClient(address string, systemCertPool *x509.CertPool
 			grpc.MaxCallSendMsgSize(MAX_MESSAGE_SIZE_BYTES),
 		),
 		grpc.WithUnaryInterceptor(FlightHeadersInterceptor(map[string]string{
-			"User-Agent": c.userAgent,
+			"user-agent": c.userAgent,
 		})),
 	}
 

--- a/config.go
+++ b/config.go
@@ -69,7 +69,7 @@ func GetSpiceUserAgent() string {
 
 	osVersion := GetOSRelease()
 
-	userAgent := fmt.Sprintf("gospice %s (%s/%s %s)", GO_SPICE_VERSION, osType, osVersion, osMachine)
+	userAgent := fmt.Sprintf("gospice/%s (%s/%s %s)", GO_SPICE_VERSION, osType, osVersion, osMachine)
 
 	// strip any non-printable ASCII characters
 	return RemoveNonPrintableASCII(userAgent)

--- a/config_test.go
+++ b/config_test.go
@@ -9,7 +9,7 @@ func TestUserAgent(t *testing.T) {
 	userAgent := GetSpiceUserAgent()
 
 	// test with a regex
-	regex := regexp.MustCompile(`gospice \d+\.\d+\.\d+ \((Linux|Windows|Darwin)/[\d\w\.\-\_]+ (x86_64|aarch64|i386)\)`)
+	regex := regexp.MustCompile(`gospice/\d+\.\d+\.\d+ \((Linux|Windows|Darwin)/[\d\w\.\-\_]+ (x86_64|aarch64|i386)\)`)
 
 	if !regex.MatchString(userAgent) {
 		t.Errorf("User agent string is not in the expected format: %s", userAgent)

--- a/datasets.go
+++ b/datasets.go
@@ -39,7 +39,7 @@ func (c *SpiceClient) RefreshDataset(ctx context.Context, dataset string, opts *
 
 	req.Header.Set("X-API-Key", c.apiKey)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Spice-User-Agent", c.userAgent)
+	req.Header.Set("user-agent", c.userAgent)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
## 🗣 Description

* Adding a custom user-agent to gospice to improve the identification of the client when making requests.
* Changing header from `x-spice-user-agent` to standard `User-Agent`

## 🔨 Related Issues

## 🤔 Concerns
