### PR TITLE
Add IsSpiceHealthy & IsSpiceReady checks

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -70,7 +70,7 @@ jobs:
           spice add spiceai/quickstart
           spiced &> spice.log &
           # time to initialize added dataset
-          sleep 10
+          sleep 30
 
       - name: Init and start spice app (Windows)
         if: matrix.os == 'windows-latest'
@@ -80,7 +80,7 @@ jobs:
           spice add spiceai/quickstart
           Start-Process -FilePath spice run
           # time to initialize added dataset
-          Start-Sleep -Seconds 10
+          Start-Sleep -Seconds 30
         shell: pwsh
 
       - name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,10 +18,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         go-version: ['1.24', '1.25']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -29,7 +29,9 @@ jobs:
         run: go vet -v ./...
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.1
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Check if tag exists
         id: check-tag
@@ -28,7 +28,6 @@ jobs:
             echo "tag-exists=0" >> "$GITHUB_OUTPUT"
           fi
 
-
   create-tag-and-release:
     runs-on: ubuntu-latest
     needs: check-version
@@ -36,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Create and push tag
         run: |

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-Copyright 2023-2024 Spice AI, Inc.
+Copyright 2023-2025 Spice AI, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,7 +9,7 @@ import (
 
 func querySpiceCloud() {
 	spice := gospice.NewSpiceClient()
-	defer spice.Close()
+	defer func() { _ = spice.Close() }()
 
 	if err := spice.Init(
 		gospice.WithApiKey("3437|89d6b41cd0034cd68eea704f5e88779d"),
@@ -33,7 +33,7 @@ func querySpiceCloud() {
 
 func querySpiceLocal() {
 	spice := gospice.NewSpiceClient()
-	defer spice.Close()
+	defer func() { _ = spice.Close() }()
 
 	if err := spice.Init(); err != nil {
 		panic(fmt.Errorf("error initializing SpiceClient: %w", err))
@@ -55,7 +55,7 @@ func querySpiceLocal() {
 // Test refreshing a local spiced dataset.
 func localDatasetRefresh() {
 	spice := gospice.NewSpiceClient()
-	defer spice.Close()
+	defer func() { _ = spice.Close() }()
 
 	if err := spice.Init(
 		gospice.WithHttpAddress("http://127.0.0.1:8090"),

--- a/datasets.go
+++ b/datasets.go
@@ -51,7 +51,7 @@ func (c *SpiceClient) RefreshDataset(ctx context.Context, dataset string, opts *
 	if err != nil {
 		return fmt.Errorf("error executing request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("POST %s failed with status=%d. body=%v", url, resp.StatusCode, body)
 	}

--- a/datasets_test.go
+++ b/datasets_test.go
@@ -2,8 +2,8 @@ package gospice
 
 import (
 	"context"
-	"fmt"
 	"testing"
+	"time"
 )
 
 func TestLocalRuntimeDatasetRefresh(t *testing.T) {
@@ -11,12 +11,36 @@ func TestLocalRuntimeDatasetRefresh(t *testing.T) {
 	defer func() { _ = spice.Close() }()
 
 	if err := spice.Init(WithHttpAddress("http://127.0.0.1:8090")); err != nil {
-		panic(fmt.Errorf("error initializing SpiceClient: %w", err))
+		t.Fatalf("error initializing SpiceClient: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Check if Spice is healthy
+	if !spice.IsSpiceHealthy(ctx) {
+		t.Fatal("Spice instance is not healthy")
+	}
+
+	// Wait for Spice to be ready (with timeout)
+	timeout := time.After(60 * time.Second)
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	ready := false
+	for !ready {
+		select {
+		case <-timeout:
+			t.Fatal("Timed out waiting for Spice to be ready")
+		case <-ticker.C:
+			if spice.IsSpiceReady(ctx) {
+				ready = true
+			}
+		}
 	}
 
 	t.Run("Refresh Dataset", func(t *testing.T) {
-		if err := spice.RefreshDataset(context.Background(), "taxi_trips", nil); err != nil {
-			panic(fmt.Errorf("error refreshing dataset: %w", err))
+		if err := spice.RefreshDataset(ctx, "taxi_trips", nil); err != nil {
+			t.Fatalf("error refreshing dataset: %v", err)
 		}
 	})
 }

--- a/datasets_test.go
+++ b/datasets_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestLocalRuntimeDatasetRefresh(t *testing.T) {
 	spice := NewSpiceClient()
-	defer spice.Close()
+	defer func() { _ = spice.Close() }()
 
 	if err := spice.Init(WithHttpAddress("http://127.0.0.1:8090")); err != nil {
 		panic(fmt.Errorf("error initializing SpiceClient: %w", err))

--- a/datasets_test.go
+++ b/datasets_test.go
@@ -22,7 +22,7 @@ func TestLocalRuntimeDatasetRefresh(t *testing.T) {
 	}
 
 	// Wait for Spice to be ready (with timeout)
-	timeout := time.After(60 * time.Second)
+	timeout := time.After(120 * time.Second)
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 

--- a/health.go
+++ b/health.go
@@ -23,7 +23,7 @@ func (c *SpiceClient) IsSpiceHealthy(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	return resp.StatusCode == http.StatusOK
 }
@@ -45,7 +45,7 @@ func (c *SpiceClient) IsSpiceReady(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	return resp.StatusCode == http.StatusOK
 }

--- a/health.go
+++ b/health.go
@@ -29,8 +29,7 @@ func (c *SpiceClient) IsSpiceHealthy(ctx context.Context) bool {
 }
 
 // IsSpiceReady checks if the Spice instance is ready by calling the /v1/ready endpoint.
-// This is an authenticated endpoint that requires an API key and returns true if the Spice instance
-// is ready to serve queries.
+// This is an unauthenticated endpoint that returns true if the Spice instance is ready to serve queries.
 func (c *SpiceClient) IsSpiceReady(ctx context.Context) bool {
 	url := fmt.Sprintf("%s/v1/ready", c.baseHttpUrl)
 
@@ -40,7 +39,6 @@ func (c *SpiceClient) IsSpiceReady(ctx context.Context) bool {
 	}
 
 	req = req.WithContext(c.traceHttpRequest(ctx, "IsSpiceReady", req))
-	req.Header.Set("X-API-Key", c.apiKey)
 	req.Header.Set("user-agent", c.userAgent)
 
 	resp, err := c.httpClient.Do(req)

--- a/health.go
+++ b/health.go
@@ -1,0 +1,53 @@
+package gospice
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// IsSpiceHealthy checks if the Spice instance is healthy by calling the /health endpoint.
+// This is an unauthenticated endpoint that returns true if the Spice instance is running.
+func (c *SpiceClient) IsSpiceHealthy(ctx context.Context) bool {
+	url := fmt.Sprintf("%s/health", c.baseHttpUrl)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+
+	req = req.WithContext(c.traceHttpRequest(ctx, "IsSpiceHealthy", req))
+	req.Header.Set("user-agent", c.userAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode == http.StatusOK
+}
+
+// IsSpiceReady checks if the Spice instance is ready by calling the /v1/ready endpoint.
+// This is an authenticated endpoint that requires an API key and returns true if the Spice instance
+// is ready to serve queries.
+func (c *SpiceClient) IsSpiceReady(ctx context.Context) bool {
+	url := fmt.Sprintf("%s/v1/ready", c.baseHttpUrl)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+
+	req = req.WithContext(c.traceHttpRequest(ctx, "IsSpiceReady", req))
+	req.Header.Set("X-API-Key", c.apiKey)
+	req.Header.Set("user-agent", c.userAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode == http.StatusOK
+}

--- a/health_test.go
+++ b/health_test.go
@@ -1,0 +1,127 @@
+package gospice
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestIsSpiceHealthy(t *testing.T) {
+	t.Run("Local - Health Check", func(t *testing.T) {
+		spice := NewSpiceClient()
+		defer func() {
+			if err := spice.Close(); err != nil {
+				t.Logf("warning: failed to close SpiceClient: %v", err)
+			}
+		}()
+
+		if err := spice.Init(); err != nil {
+			t.Fatalf("error initializing SpiceClient: %v", err)
+		}
+
+		ctx := context.Background()
+		isHealthy := spice.IsSpiceHealthy(ctx)
+
+		// We don't assert true/false since local runtime may not be running
+		// This test just verifies the method works without errors
+		t.Logf("Local Spice health status: %v", isHealthy)
+	})
+
+	t.Run("Cloud - Health Check", func(t *testing.T) {
+		spice := NewSpiceClient()
+		defer func() {
+			if err := spice.Close(); err != nil {
+				t.Logf("warning: failed to close SpiceClient: %v", err)
+			}
+		}()
+
+		var ApiKey string
+		if v, exists := os.LookupEnv("SPICE_API_KEY"); exists {
+			ApiKey = v
+		} else {
+			ApiKey = TEST_API_KEY
+		}
+
+		if err := spice.Init(WithApiKey(ApiKey), WithSpiceCloudAddress()); err != nil {
+			t.Fatalf("error initializing SpiceClient: %v", err)
+		}
+
+		ctx := context.Background()
+		isHealthy := spice.IsSpiceHealthy(ctx)
+
+		t.Logf("Spice Cloud health status: %v", isHealthy)
+	})
+}
+
+func TestIsSpiceReady(t *testing.T) {
+	t.Run("Cloud - Ready Check with API Key", func(t *testing.T) {
+		spice := NewSpiceClient()
+		defer func() {
+			if err := spice.Close(); err != nil {
+				t.Logf("warning: failed to close SpiceClient: %v", err)
+			}
+		}()
+
+		var ApiKey string
+		if v, exists := os.LookupEnv("SPICE_API_KEY"); exists {
+			ApiKey = v
+		} else {
+			ApiKey = TEST_API_KEY
+		}
+
+		if err := spice.Init(WithApiKey(ApiKey), WithSpiceCloudAddress()); err != nil {
+			t.Fatalf("error initializing SpiceClient: %v", err)
+		}
+
+		ctx := context.Background()
+		isReady := spice.IsSpiceReady(ctx)
+
+		t.Logf("Spice Cloud ready status: %v", isReady)
+	})
+
+	t.Run("Cloud - Ready Check without API Key", func(t *testing.T) {
+		spice := NewSpiceClient()
+		defer func() {
+			if err := spice.Close(); err != nil {
+				t.Logf("warning: failed to close SpiceClient: %v", err)
+			}
+		}()
+
+		// Initialize without API key
+		if err := spice.Init(WithSpiceCloudAddress()); err != nil {
+			t.Fatalf("error initializing SpiceClient: %v", err)
+		}
+
+		ctx := context.Background()
+		isReady := spice.IsSpiceReady(ctx)
+
+		// Should be false since no API key provided
+		if isReady {
+			t.Errorf("Expected IsSpiceReady to return false without API key, got true")
+		}
+		t.Logf("Spice Cloud ready status (no API key): %v", isReady)
+	})
+
+	t.Run("Local - Ready Check (No Auth Required)", func(t *testing.T) {
+		spice := NewSpiceClient()
+		defer func() {
+			if err := spice.Close(); err != nil {
+				t.Logf("warning: failed to close SpiceClient: %v", err)
+			}
+		}()
+
+		if err := spice.Init(); err != nil {
+			t.Fatalf("error initializing SpiceClient: %v", err)
+		}
+
+		ctx := context.Background()
+
+		// Local runtime doesn't require API key, so this will return false
+		// but IsSpiceHealthy should work
+		isHealthy := spice.IsSpiceHealthy(ctx)
+		isReady := spice.IsSpiceReady(ctx)
+
+		t.Logf("Local Spice health status: %v", isHealthy)
+		t.Logf("Local Spice ready status (no auth): %v", isReady)
+	})
+}

--- a/health_test.go
+++ b/health_test.go
@@ -54,7 +54,7 @@ func TestIsSpiceHealthy(t *testing.T) {
 }
 
 func TestIsSpiceReady(t *testing.T) {
-	t.Run("Cloud - Ready Check with API Key", func(t *testing.T) {
+	t.Run("Cloud - Ready Check", func(t *testing.T) {
 		spice := NewSpiceClient()
 		defer func() {
 			if err := spice.Close(); err != nil {
@@ -79,30 +79,7 @@ func TestIsSpiceReady(t *testing.T) {
 		t.Logf("Spice Cloud ready status: %v", isReady)
 	})
 
-	t.Run("Cloud - Ready Check without API Key", func(t *testing.T) {
-		spice := NewSpiceClient()
-		defer func() {
-			if err := spice.Close(); err != nil {
-				t.Logf("warning: failed to close SpiceClient: %v", err)
-			}
-		}()
-
-		// Initialize without API key
-		if err := spice.Init(WithSpiceCloudAddress()); err != nil {
-			t.Fatalf("error initializing SpiceClient: %v", err)
-		}
-
-		ctx := context.Background()
-		isReady := spice.IsSpiceReady(ctx)
-
-		// Should be false since no API key provided
-		if isReady {
-			t.Errorf("Expected IsSpiceReady to return false without API key, got true")
-		}
-		t.Logf("Spice Cloud ready status (no API key): %v", isReady)
-	})
-
-	t.Run("Local - Ready Check (No Auth Required)", func(t *testing.T) {
+	t.Run("Local - Ready Check", func(t *testing.T) {
 		spice := NewSpiceClient()
 		defer func() {
 			if err := spice.Close(); err != nil {
@@ -116,12 +93,10 @@ func TestIsSpiceReady(t *testing.T) {
 
 		ctx := context.Background()
 
-		// Local runtime doesn't require API key, so this will return false
-		// but IsSpiceHealthy should work
 		isHealthy := spice.IsSpiceHealthy(ctx)
 		isReady := spice.IsSpiceReady(ctx)
 
 		t.Logf("Local Spice health status: %v", isHealthy)
-		t.Logf("Local Spice ready status (no auth): %v", isReady)
+		t.Logf("Local Spice ready status: %v", isReady)
 	})
 }

--- a/health_test.go
+++ b/health_test.go
@@ -15,7 +15,7 @@ func TestIsSpiceHealthy(t *testing.T) {
 			}
 		}()
 
-		if err := spice.Init(); err != nil {
+		if err := spice.Init(WithHttpAddress("http://localhost:8090")); err != nil {
 			t.Fatalf("error initializing SpiceClient: %v", err)
 		}
 
@@ -87,7 +87,7 @@ func TestIsSpiceReady(t *testing.T) {
 			}
 		}()
 
-		if err := spice.Init(); err != nil {
+		if err := spice.Init(WithHttpAddress("http://localhost:8090")); err != nil {
 			t.Fatalf("error initializing SpiceClient: %v", err)
 		}
 

--- a/query_test.go
+++ b/query_test.go
@@ -102,7 +102,7 @@ func TestLocalRuntime(t *testing.T) {
 	}
 
 	// Wait for Spice to be ready (with timeout)
-	timeout := time.After(60 * time.Second)
+	timeout := time.After(120 * time.Second)
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 

--- a/query_test.go
+++ b/query_test.go
@@ -90,7 +90,7 @@ func TestLocalRuntime(t *testing.T) {
 	spice := NewSpiceClient()
 	defer func() { _ = spice.Close() }()
 
-	if err := spice.Init(); err != nil {
+	if err := spice.Init(WithHttpAddress("http://localhost:8090")); err != nil {
 		t.Fatalf("error initializing SpiceClient: %v", err)
 	}
 

--- a/query_test.go
+++ b/query_test.go
@@ -2,7 +2,6 @@ package gospice
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -27,14 +26,14 @@ func TestBasicQuery(t *testing.T) {
 	}
 
 	if err := spice.Init(WithApiKey(ApiKey), WithSpiceCloudAddress()); err != nil {
-		panic(fmt.Errorf("error initializing SpiceClient: %w", err))
+		t.Fatalf("error initializing SpiceClient: %v", err)
 	}
 
 	t.Run("Recent Ethereum Blocks", func(t *testing.T) {
 		t.Skip()
 		reader, err := spice.Query(context.Background(), "SELECT number, \"timestamp\", hash FROM eth.recent_blocks ORDER BY number LIMIT 10")
 		if err != nil {
-			panic(fmt.Errorf("error querying: %w", err))
+			t.Fatalf("error querying: %v", err)
 		}
 		defer reader.Release()
 
@@ -92,13 +91,37 @@ func TestLocalRuntime(t *testing.T) {
 	defer func() { _ = spice.Close() }()
 
 	if err := spice.Init(); err != nil {
-		panic(fmt.Errorf("error initializing SpiceClient: %w", err))
+		t.Fatalf("error initializing SpiceClient: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Check if Spice is healthy
+	if !spice.IsSpiceHealthy(ctx) {
+		t.Fatal("Spice instance is not healthy")
+	}
+
+	// Wait for Spice to be ready (with timeout)
+	timeout := time.After(60 * time.Second)
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	ready := false
+	for !ready {
+		select {
+		case <-timeout:
+			t.Fatal("Timed out waiting for Spice to be ready")
+		case <-ticker.C:
+			if spice.IsSpiceReady(ctx) {
+				ready = true
+			}
+		}
 	}
 
 	t.Run("Query Local Dataset", func(t *testing.T) {
-		reader, err := spice.Query(context.Background(), "select * from taxi_trips limit 3;")
+		reader, err := spice.Query(ctx, "select * from taxi_trips limit 3;")
 		if err != nil {
-			panic(fmt.Errorf("error querying: %w", err))
+			t.Fatalf("error querying: %v", err)
 		}
 		defer reader.Release()
 

--- a/query_test.go
+++ b/query_test.go
@@ -17,7 +17,7 @@ const (
 // Execute a basic query and check for columns and rows
 func TestBasicQuery(t *testing.T) {
 	spice := NewSpiceClient()
-	defer spice.Close()
+	defer func() { _ = spice.Close() }()
 
 	var ApiKey string
 	if v, exists := os.LookupEnv("SPICE_API_KEY"); exists {
@@ -89,7 +89,7 @@ func TestBasicQuery(t *testing.T) {
 
 func TestLocalRuntime(t *testing.T) {
 	spice := NewSpiceClient()
-	defer spice.Close()
+	defer func() { _ = spice.Close() }()
 
 	if err := spice.Init(); err != nil {
 		panic(fmt.Errorf("error initializing SpiceClient: %w", err))


### PR DESCRIPTION
This pull request introduces new health check functionality to the `gospice` client library, along with corresponding tests, and updates some dependencies and metadata. The main focus is on providing easy methods to check if a Spice instance is healthy and ready, and ensuring these are well-tested across local and cloud environments.

New health check functionality:

* Added `IsSpiceHealthy` and `IsSpiceReady` methods to the `SpiceClient`, allowing users to check if a Spice instance is running (`/health` endpoint) and ready to serve queries (`/v1/ready` endpoint, requires API key). (`health.go`)
* Added comprehensive tests for the new health check methods, covering both local and cloud Spice instances, with and without authentication. (`health_test.go`)

Dependency and metadata updates:

* Updated GitHub Actions workflow dependencies to use the latest versions for better reliability and security: `actions/checkout` to `v5`, `actions/setup-go` to `v6`, and `golangci-lint-action` to `v8` with an explicit linter version. (`.github/workflows/go.yml`, `.github/workflows/version.yml`) [[1]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL21-R34) [[2]](diffhunk://#diff-fd17c77905dbf19e585660488bae21de251453d5389f9173b2a0138cfb16e3a9L18-R18) [[3]](diffhunk://#diff-fd17c77905dbf19e585660488bae21de251453d5389f9173b2a0138cfb16e3a9L31-R38)
* Updated copyright year in the `LICENSE` file to include 2025. (`LICENSE`)