### PR TITLE
Allow queries without authentication if no API key is provided

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,8 +63,16 @@ jobs:
           cd spice_qs
           spice add spiceai/quickstart
           spice run &> spice.log &
-          # time to initialize added dataset
-          sleep 30
+          # Wait for Spice to be ready
+          echo "Waiting for Spice to be ready..."
+          for i in {1..60}; do
+            if curl -s http://localhost:8090/v1/ready 2>/dev/null | grep -q "ready"; then
+              echo "Spice is ready!"
+              break
+            fi
+            echo "Waiting... ($i/60)"
+            sleep 1
+          done
 
       - name: Init and start spice app (Windows)
         if: matrix.os == 'windows-latest'
@@ -72,12 +80,40 @@ jobs:
           spice init spice_qs
           cd spice_qs
           spice add spiceai/quickstart
-          Start-Process -FilePath spice run
-          # time to initialize added dataset
-          Start-Sleep -Seconds 30
+          Start-Process -FilePath "spice" -ArgumentList "run" -RedirectStandardOutput "spice.log" -RedirectStandardError "spice.err.log"
+          # Wait for Spice to be ready
+          Write-Host "Waiting for Spice to be ready..."
+          for ($i = 1; $i -le 60; $i++) {
+            try {
+              $response = Invoke-WebRequest -Uri "http://localhost:8090/v1/ready" -UseBasicParsing -ErrorAction Stop
+              if ($response.Content -match "ready") {
+                Write-Host "Spice is ready!"
+                break
+              }
+            } catch {
+              # Ignore errors, keep waiting
+            }
+            Write-Host "Waiting... ($i/60)"
+            Start-Sleep -Seconds 1
+          }
         shell: pwsh
 
       - name: Test
         env:
           SPICE_API_KEY: ${{ secrets.SPICE_CLOUD_API_KEY }}
         run: go test -v ./...
+
+      - name: Print Spice logs (Unix)
+        if: always() && matrix.os != 'windows-latest'
+        run: |
+          echo "=== Spice Runtime Logs ==="
+          cat spice_qs/spice.log || echo "No log file found"
+
+      - name: Print Spice logs (Windows)
+        if: always() && matrix.os == 'windows-latest'
+        run: |
+          Write-Host "=== Spice Runtime Logs (stdout) ==="
+          Get-Content spice_qs\spice.log -ErrorAction SilentlyContinue
+          Write-Host "=== Spice Runtime Logs (stderr) ==="
+          Get-Content spice_qs\spice.err.log -ErrorAction SilentlyContinue
+        shell: pwsh

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,7 +79,5 @@ jobs:
 
       - name: Test
         env:
-          SPICE_HTTP_URL: ${{ vars.SPICE_HTTP_URL }}
-          SPICE_FLIGHT_URL: ${{ vars.SPICE_FLIGHT_URL }}
           SPICE_API_KEY: ${{ secrets.SPICE_CLOUD_API_KEY }}
         run: go test -v ./...

--- a/adbc_test.go
+++ b/adbc_test.go
@@ -11,7 +11,7 @@ import (
 // TestADBCCloudBasicQuery tests basic ADBC query functionality against Spice Cloud
 func TestADBCCloudBasicQuery(t *testing.T) {
 	// Uses SPICE_FLIGHT_URL and SPICE_HTTP_URL env vars if set
-	// e.g., SPICE_FLIGHT_URL="dev-data.spiceai.io:443" SPICE_HTTP_URL="https://dev-data.spiceai.io" for dev
+	// e.g., SPICE_FLIGHT_URL="flight.spiceai.io:443" SPICE_HTTP_URL="https://data.spiceai.io"
 
 	spice := NewSpiceClient()
 	defer func() {

--- a/adbc_test.go
+++ b/adbc_test.go
@@ -20,11 +20,9 @@ func TestADBCCloudBasicQuery(t *testing.T) {
 		}
 	}()
 
-	var ApiKey string
-	if v, exists := os.LookupEnv("SPICE_API_KEY"); exists {
-		ApiKey = v
-	} else {
-		ApiKey = TEST_API_KEY
+	ApiKey, exists := os.LookupEnv("SPICE_API_KEY")
+	if !exists || ApiKey == "" {
+		t.Skip("SPICE_API_KEY not set, skipping cloud authentication test")
 	}
 
 	if err := spice.Init(WithApiKey(ApiKey), WithSpiceCloudAddress()); err != nil {

--- a/adbc_test.go
+++ b/adbc_test.go
@@ -61,11 +61,11 @@ func TestADBCCloudBasicQuery(t *testing.T) {
 		}
 	})
 
-	t.Run("Cloud - TPC-H Parameterized Query", func(t *testing.T) {
+	t.Run("Cloud - Parameterized Query", func(t *testing.T) {
 		reader, err := spice.SqlWithParams(
 			context.Background(),
-			"SELECT c_custkey, c_name FROM tpch.customer WHERE c_custkey > $1 ORDER BY c_custkey LIMIT 5",
-			100,
+			"SELECT trip_distance, fare_amount FROM taxi_trips WHERE trip_distance > $1 ORDER BY trip_distance LIMIT 5",
+			5.0,
 		)
 		if err != nil {
 			t.Fatalf("error querying: %v", err)
@@ -73,11 +73,11 @@ func TestADBCCloudBasicQuery(t *testing.T) {
 		defer reader.Release()
 
 		schema := reader.Schema()
-		if !schema.HasField("c_custkey") {
-			t.Fatalf("Schema does not have field 'c_custkey'")
+		if !schema.HasField("trip_distance") {
+			t.Fatalf("Schema does not have field 'trip_distance'")
 		}
-		if !schema.HasField("c_name") {
-			t.Fatalf("Schema does not have field 'c_name'")
+		if !schema.HasField("fare_amount") {
+			t.Fatalf("Schema does not have field 'fare_amount'")
 		}
 
 		recordCount := 0
@@ -85,36 +85,19 @@ func TestADBCCloudBasicQuery(t *testing.T) {
 			record := reader.RecordBatch()
 			recordCount++
 
-			// Validate c_custkey > 100
-			custKeyCol := record.Column(0)
+			// Validate trip_distance > 5.0
+			tripDistCol := record.Column(0)
 			for i := 0; i < int(record.NumRows()); i++ {
-				if !custKeyCol.IsNull(i) {
-					switch v := custKeyCol.(type) {
-					case *array.Int64:
-						if v.Value(i) <= 100 {
-							t.Errorf("Expected c_custkey > 100, got %d", v.Value(i))
+				if !tripDistCol.IsNull(i) {
+					switch v := tripDistCol.(type) {
+					case *array.Float64:
+						if v.Value(i) <= 5.0 {
+							t.Errorf("Expected trip_distance > 5.0, got %f", v.Value(i))
 						}
-					case *array.Int32:
-						if v.Value(i) <= 100 {
-							t.Errorf("Expected c_custkey > 100, got %d", v.Value(i))
+					case *array.Float32:
+						if v.Value(i) <= 5.0 {
+							t.Errorf("Expected trip_distance > 5.0, got %f", v.Value(i))
 						}
-					}
-				}
-			}
-
-			// Validate c_name is non-empty
-			nameCol := record.Column(1)
-			for i := 0; i < int(record.NumRows()); i++ {
-				if !nameCol.IsNull(i) {
-					var name string
-					switch v := nameCol.(type) {
-					case *array.String:
-						name = v.Value(i)
-					case *array.LargeString:
-						name = v.Value(i)
-					}
-					if len(name) == 0 {
-						t.Errorf("Expected non-empty customer name")
 					}
 				}
 			}
@@ -127,13 +110,13 @@ func TestADBCCloudBasicQuery(t *testing.T) {
 		}
 	})
 
-	t.Run("Cloud - TPC-H Multiple Parameter Types", func(t *testing.T) {
+	t.Run("Cloud - Multiple Parameter Types", func(t *testing.T) {
 		reader, err := spice.SqlWithParams(
 			context.Background(),
-			"SELECT c_custkey, c_name, c_acctbal, c_mktsegment FROM tpch.customer WHERE c_custkey > $1 AND c_acctbal > $2 AND c_mktsegment = $3 ORDER BY c_custkey LIMIT 10",
-			100,
-			5000.0,
-			"BUILDING",
+			"SELECT trip_distance, fare_amount, payment_type FROM taxi_trips WHERE trip_distance > $1 AND fare_amount > $2 AND payment_type = $3 ORDER BY trip_distance LIMIT 10",
+			5.0,
+			20.0,
+			int64(1),
 		)
 		if err != nil {
 			t.Fatalf("error querying: %v", err)
@@ -141,7 +124,7 @@ func TestADBCCloudBasicQuery(t *testing.T) {
 		defer reader.Release()
 
 		schema := reader.Schema()
-		fields := []string{"c_custkey", "c_name", "c_acctbal", "c_mktsegment"}
+		fields := []string{"trip_distance", "fare_amount", "payment_type"}
 		for _, field := range fields {
 			if !schema.HasField(field) {
 				t.Fatalf("Schema does not have field '%s'", field)
@@ -155,48 +138,48 @@ func TestADBCCloudBasicQuery(t *testing.T) {
 
 			// Validate all parameter conditions
 			for i := 0; i < int(record.NumRows()); i++ {
-				// c_custkey > 100
-				custKeyCol := record.Column(0)
-				if !custKeyCol.IsNull(i) {
-					switch v := custKeyCol.(type) {
-					case *array.Int64:
-						if v.Value(i) <= 100 {
-							t.Errorf("Expected c_custkey > 100, got %d", v.Value(i))
-						}
-					case *array.Int32:
-						if v.Value(i) <= 100 {
-							t.Errorf("Expected c_custkey > 100, got %d", v.Value(i))
-						}
-					}
-				}
-
-				// c_acctbal > 5000.0
-				acctBalCol := record.Column(2)
-				if !acctBalCol.IsNull(i) {
-					switch v := acctBalCol.(type) {
+				// trip_distance > 5.0
+				tripDistCol := record.Column(0)
+				if !tripDistCol.IsNull(i) {
+					switch v := tripDistCol.(type) {
 					case *array.Float64:
-						if v.Value(i) <= 5000.0 {
-							t.Errorf("Expected c_acctbal > 5000.0, got %f", v.Value(i))
+						if v.Value(i) <= 5.0 {
+							t.Errorf("Expected trip_distance > 5.0, got %f", v.Value(i))
 						}
 					case *array.Float32:
-						if v.Value(i) <= 5000.0 {
-							t.Errorf("Expected c_acctbal > 5000.0, got %f", v.Value(i))
+						if v.Value(i) <= 5.0 {
+							t.Errorf("Expected trip_distance > 5.0, got %f", v.Value(i))
 						}
 					}
 				}
 
-				// c_mktsegment = "BUILDING"
-				mktSegCol := record.Column(3)
-				if !mktSegCol.IsNull(i) {
-					var mktSeg string
-					switch v := mktSegCol.(type) {
-					case *array.String:
-						mktSeg = v.Value(i)
-					case *array.LargeString:
-						mktSeg = v.Value(i)
+				// fare_amount > 20.0
+				fareCol := record.Column(1)
+				if !fareCol.IsNull(i) {
+					switch v := fareCol.(type) {
+					case *array.Float64:
+						if v.Value(i) <= 20.0 {
+							t.Errorf("Expected fare_amount > 20.0, got %f", v.Value(i))
+						}
+					case *array.Float32:
+						if v.Value(i) <= 20.0 {
+							t.Errorf("Expected fare_amount > 20.0, got %f", v.Value(i))
+						}
 					}
-					if mktSeg != "BUILDING" {
-						t.Errorf("Expected c_mktsegment 'BUILDING', got '%s'", mktSeg)
+				}
+
+				// payment_type = 1
+				paymentTypeCol := record.Column(2)
+				if !paymentTypeCol.IsNull(i) {
+					switch v := paymentTypeCol.(type) {
+					case *array.Int64:
+						if v.Value(i) != 1 {
+							t.Errorf("Expected payment_type 1, got %d", v.Value(i))
+						}
+					case *array.Int32:
+						if v.Value(i) != 1 {
+							t.Errorf("Expected payment_type 1, got %d", v.Value(i))
+						}
 					}
 				}
 			}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -17,11 +17,9 @@ func BenchmarkCloudQuery(b *testing.B) {
 		}
 	}()
 
-	var ApiKey string
-	if v, exists := os.LookupEnv("SPICE_API_KEY"); exists {
-		ApiKey = v
-	} else {
-		ApiKey = TEST_API_KEY
+	ApiKey, exists := os.LookupEnv("SPICE_API_KEY")
+	if !exists || ApiKey == "" {
+		b.Skip("SPICE_API_KEY not set, skipping cloud authentication test")
 	}
 
 	if err := spice.Init(WithApiKey(ApiKey), WithSpiceCloudAddress()); err != nil {
@@ -60,11 +58,9 @@ func BenchmarkCloudSqlWithParams(b *testing.B) {
 		}
 	}()
 
-	var ApiKey string
-	if v, exists := os.LookupEnv("SPICE_API_KEY"); exists {
-		ApiKey = v
-	} else {
-		ApiKey = TEST_API_KEY
+	ApiKey, exists := os.LookupEnv("SPICE_API_KEY")
+	if !exists || ApiKey == "" {
+		b.Skip("SPICE_API_KEY not set, skipping cloud authentication test")
 	}
 
 	if err := spice.Init(WithApiKey(ApiKey), WithSpiceCloudAddress()); err != nil {
@@ -232,11 +228,9 @@ func BenchmarkClientInitialization(b *testing.B) {
 	})
 
 	b.Run("Cloud", func(b *testing.B) {
-		var ApiKey string
-		if v, exists := os.LookupEnv("SPICE_API_KEY"); exists {
-			ApiKey = v
-		} else {
-			ApiKey = TEST_API_KEY
+		ApiKey, exists := os.LookupEnv("SPICE_API_KEY")
+		if !exists || ApiKey == "" {
+			b.Skip("SPICE_API_KEY not set, skipping cloud authentication test")
 		}
 
 		for i := 0; i < b.N; i++ {

--- a/health_test.go
+++ b/health_test.go
@@ -35,11 +35,9 @@ func TestIsSpiceHealthy(t *testing.T) {
 			}
 		}()
 
-		var ApiKey string
-		if v, exists := os.LookupEnv("SPICE_API_KEY"); exists {
-			ApiKey = v
-		} else {
-			ApiKey = TEST_API_KEY
+		ApiKey, exists := os.LookupEnv("SPICE_API_KEY")
+		if !exists || ApiKey == "" {
+			t.Skip("SPICE_API_KEY not set, skipping cloud authentication test")
 		}
 
 		if err := spice.Init(WithApiKey(ApiKey), WithSpiceCloudAddress()); err != nil {
@@ -62,11 +60,9 @@ func TestIsSpiceReady(t *testing.T) {
 			}
 		}()
 
-		var ApiKey string
-		if v, exists := os.LookupEnv("SPICE_API_KEY"); exists {
-			ApiKey = v
-		} else {
-			ApiKey = TEST_API_KEY
+		ApiKey, exists := os.LookupEnv("SPICE_API_KEY")
+		if !exists || ApiKey == "" {
+			t.Skip("SPICE_API_KEY not set, skipping cloud authentication test")
 		}
 
 		if err := spice.Init(WithApiKey(ApiKey), WithSpiceCloudAddress()); err != nil {

--- a/query.go
+++ b/query.go
@@ -55,9 +55,14 @@ func queryInternal(ctx context.Context, client flight.Client, appId string, apiK
 		return nil, fmt.Errorf("flight client is not initialized")
 	}
 
-	authContext, err := client.AuthenticateBasicToken(ctx, appId, apiKey)
-	if err != nil {
-		return nil, err
+	// Only authenticate if credentials are provided
+	queryCtx := ctx
+	if appId != "" && apiKey != "" {
+		authContext, err := client.AuthenticateBasicToken(ctx, appId, apiKey)
+		if err != nil {
+			return nil, err
+		}
+		queryCtx = authContext
 	}
 
 	fd := &flight.FlightDescriptor{
@@ -65,12 +70,12 @@ func queryInternal(ctx context.Context, client flight.Client, appId string, apiK
 		Cmd:  []byte(sql),
 	}
 
-	info, err := client.GetFlightInfo(authContext, fd)
+	info, err := client.GetFlightInfo(queryCtx, fd)
 	if err != nil {
 		return nil, err
 	}
 
-	stream, err := client.DoGet(authContext, info.Endpoint[0].Ticket)
+	stream, err := client.DoGet(queryCtx, info.Endpoint[0].Ticket)
 	if err != nil {
 		return nil, err
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -235,10 +235,10 @@ func TestSqlWithAuth(t *testing.T) {
 
 	// Check if Spice Cloud is healthy and ready
 	if !spice.IsSpiceHealthy(ctx) {
-		t.Skip("Spice Cloud is not healthy, skipping test")
+		t.Fatal("Spice Cloud is not healthy")
 	}
 	if !spice.IsSpiceReady(ctx) {
-		t.Skip("Spice Cloud is not ready (check API key), skipping test")
+		t.Fatal("Spice Cloud is not ready (check API key)")
 	}
 
 	t.Run("Sql with auth - simple query", func(t *testing.T) {

--- a/query_test.go
+++ b/query_test.go
@@ -265,19 +265,19 @@ func TestSqlWithAuth(t *testing.T) {
 		}
 	})
 
-	t.Run("Sql with auth - TPC-H query", func(t *testing.T) {
-		reader, err := spice.Sql(ctx, "SELECT c_custkey, c_name FROM tpch.customer ORDER BY c_custkey LIMIT 5")
+	t.Run("Sql with auth - taxi_trips query", func(t *testing.T) {
+		reader, err := spice.Sql(ctx, "SELECT trip_distance, fare_amount FROM taxi_trips ORDER BY trip_distance LIMIT 5")
 		if err != nil {
 			t.Fatalf("Sql with auth failed: %v", err)
 		}
 		defer reader.Release()
 
 		schema := reader.Schema()
-		if !schema.HasField("c_custkey") {
-			t.Fatalf("Schema does not have field 'c_custkey'")
+		if !schema.HasField("trip_distance") {
+			t.Fatalf("Schema does not have field 'trip_distance'")
 		}
-		if !schema.HasField("c_name") {
-			t.Fatalf("Schema does not have field 'c_name'")
+		if !schema.HasField("fare_amount") {
+			t.Fatalf("Schema does not have field 'fare_amount'")
 		}
 
 		rowCount := 0

--- a/query_test.go
+++ b/query_test.go
@@ -225,15 +225,13 @@ func TestSqlWithoutAuth(t *testing.T) {
 
 // TestSqlWithAuth tests the Sql method with authentication against Spice Cloud.
 func TestSqlWithAuth(t *testing.T) {
+	ApiKey, exists := os.LookupEnv("SPICE_API_KEY")
+	if !exists || ApiKey == "" {
+		t.Skip("SPICE_API_KEY not set, skipping cloud authentication test")
+	}
+
 	spice := NewSpiceClient()
 	defer func() { _ = spice.Close() }()
-
-	var ApiKey string
-	if v, exists := os.LookupEnv("SPICE_API_KEY"); exists {
-		ApiKey = v
-	} else {
-		ApiKey = TEST_API_KEY
-	}
 
 	if err := spice.Init(WithApiKey(ApiKey), WithSpiceCloudAddress()); err != nil {
 		t.Fatalf("error initializing SpiceClient: %v", err)

--- a/query_test.go
+++ b/query_test.go
@@ -133,7 +133,7 @@ func TestLocalRuntime(t *testing.T) {
 }
 
 // TestSqlWithoutAuth tests the Sql method without authentication against local Spice runtime.
-// This verifies that the fix for "no authorization header on the response" works correctly.
+// This verifies that queries work correctly without authentication when no API key is provided.
 func TestSqlWithoutAuth(t *testing.T) {
 	spice := NewSpiceClient()
 	defer func() { _ = spice.Close() }()
@@ -151,7 +151,7 @@ func TestSqlWithoutAuth(t *testing.T) {
 	}
 
 	// Wait for Spice to be ready (with timeout)
-	timeout := time.After(30 * time.Second)
+	timeout := time.After(120 * time.Second)
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 

--- a/query_test.go
+++ b/query_test.go
@@ -131,3 +131,176 @@ func TestLocalRuntime(t *testing.T) {
 		}
 	})
 }
+
+// TestSqlWithoutAuth tests the Sql method without authentication against local Spice runtime.
+// This verifies that the fix for "no authorization header on the response" works correctly.
+func TestSqlWithoutAuth(t *testing.T) {
+	spice := NewSpiceClient()
+	defer func() { _ = spice.Close() }()
+
+	// Initialize without API key - this should work with local runtime
+	if err := spice.Init(WithHttpAddress("http://localhost:8090")); err != nil {
+		t.Fatalf("error initializing SpiceClient: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Check if Spice is healthy
+	if !spice.IsSpiceHealthy(ctx) {
+		t.Skip("Local Spice instance is not healthy, skipping test")
+	}
+
+	// Wait for Spice to be ready (with timeout)
+	timeout := time.After(30 * time.Second)
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	ready := false
+	for !ready {
+		select {
+		case <-timeout:
+			t.Skip("Timed out waiting for Spice to be ready, skipping test")
+		case <-ticker.C:
+			if spice.IsSpiceReady(ctx) {
+				ready = true
+			}
+		}
+	}
+
+	t.Run("Sql without auth - simple query", func(t *testing.T) {
+		reader, err := spice.Sql(ctx, "SELECT 1 as num")
+		if err != nil {
+			t.Fatalf("Sql without auth failed: %v", err)
+		}
+		defer reader.Release()
+
+		schema := reader.Schema()
+		if !schema.HasField("num") {
+			t.Fatalf("Schema does not have field 'num'")
+		}
+
+		rowCount := 0
+		for reader.Next() {
+			record := reader.RecordBatch()
+			rowCount += int(record.NumRows())
+			record.Release()
+		}
+
+		if rowCount != 1 {
+			t.Fatalf("Expected 1 row, got %d", rowCount)
+		}
+	})
+
+	t.Run("Sql without auth - dataset query", func(t *testing.T) {
+		reader, err := spice.Sql(ctx, "SELECT trip_distance, fare_amount FROM taxi_trips LIMIT 5")
+		if err != nil {
+			t.Fatalf("Sql without auth failed: %v", err)
+		}
+		defer reader.Release()
+
+		schema := reader.Schema()
+		if !schema.HasField("trip_distance") {
+			t.Fatalf("Schema does not have field 'trip_distance'")
+		}
+		if !schema.HasField("fare_amount") {
+			t.Fatalf("Schema does not have field 'fare_amount'")
+		}
+
+		rowCount := 0
+		for reader.Next() {
+			record := reader.RecordBatch()
+			rowCount += int(record.NumRows())
+			record.Release()
+		}
+
+		if rowCount == 0 {
+			t.Fatalf("Expected at least 1 row, got 0")
+		}
+		if rowCount > 5 {
+			t.Fatalf("Expected at most 5 rows, got %d", rowCount)
+		}
+		t.Logf("Sql without auth returned %d rows", rowCount)
+	})
+}
+
+// TestSqlWithAuth tests the Sql method with authentication against Spice Cloud.
+func TestSqlWithAuth(t *testing.T) {
+	spice := NewSpiceClient()
+	defer func() { _ = spice.Close() }()
+
+	var ApiKey string
+	if v, exists := os.LookupEnv("SPICE_API_KEY"); exists {
+		ApiKey = v
+	} else {
+		ApiKey = TEST_API_KEY
+	}
+
+	if err := spice.Init(WithApiKey(ApiKey), WithSpiceCloudAddress()); err != nil {
+		t.Fatalf("error initializing SpiceClient: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Check if Spice Cloud is healthy and ready
+	if !spice.IsSpiceHealthy(ctx) {
+		t.Skip("Spice Cloud is not healthy, skipping test")
+	}
+	if !spice.IsSpiceReady(ctx) {
+		t.Skip("Spice Cloud is not ready (check API key), skipping test")
+	}
+
+	t.Run("Sql with auth - simple query", func(t *testing.T) {
+		reader, err := spice.Sql(ctx, "SELECT 1 as num")
+		if err != nil {
+			t.Fatalf("Sql with auth failed: %v", err)
+		}
+		defer reader.Release()
+
+		schema := reader.Schema()
+		if !schema.HasField("num") {
+			t.Fatalf("Schema does not have field 'num'")
+		}
+
+		rowCount := 0
+		for reader.Next() {
+			record := reader.RecordBatch()
+			rowCount += int(record.NumRows())
+			record.Release()
+		}
+
+		if rowCount != 1 {
+			t.Fatalf("Expected 1 row, got %d", rowCount)
+		}
+	})
+
+	t.Run("Sql with auth - TPC-H query", func(t *testing.T) {
+		reader, err := spice.Sql(ctx, "SELECT c_custkey, c_name FROM tpch.customer ORDER BY c_custkey LIMIT 5")
+		if err != nil {
+			t.Fatalf("Sql with auth failed: %v", err)
+		}
+		defer reader.Release()
+
+		schema := reader.Schema()
+		if !schema.HasField("c_custkey") {
+			t.Fatalf("Schema does not have field 'c_custkey'")
+		}
+		if !schema.HasField("c_name") {
+			t.Fatalf("Schema does not have field 'c_name'")
+		}
+
+		rowCount := 0
+		for reader.Next() {
+			record := reader.RecordBatch()
+			rowCount += int(record.NumRows())
+			record.Release()
+		}
+
+		if rowCount == 0 {
+			t.Fatalf("Expected at least 1 row, got 0")
+		}
+		if rowCount > 5 {
+			t.Fatalf("Expected at most 5 rows, got %d", rowCount)
+		}
+		t.Logf("Sql with auth returned %d rows", rowCount)
+	})
+}

--- a/query_test.go
+++ b/query_test.go
@@ -9,20 +9,14 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 )
 
-const (
-	TEST_API_KEY = "323337|b42eceab2e7c4a60a04ad57bebea830d" // spice.ai/spicehq/gospice-tests
-)
-
 // Execute a basic query and check for columns and rows
 func TestBasicQuery(t *testing.T) {
 	spice := NewSpiceClient()
 	defer func() { _ = spice.Close() }()
 
-	var ApiKey string
-	if v, exists := os.LookupEnv("SPICE_API_KEY"); exists {
-		ApiKey = v
-	} else {
-		ApiKey = TEST_API_KEY
+	ApiKey, exists := os.LookupEnv("SPICE_API_KEY")
+	if !exists || ApiKey == "" {
+		t.Skip("SPICE_API_KEY not set, skipping cloud authentication test")
 	}
 
 	if err := spice.Init(WithApiKey(ApiKey), WithSpiceCloudAddress()); err != nil {


### PR DESCRIPTION
## 🗣 Description

This pull request improves authentication handling for both cloud and local Spice runtimes, refactors tests and benchmarks to skip cloud tests if the API key is not set, and introduces more robust test coverage for authenticated and unauthenticated queries. The changes also update parameterized query tests to use the `taxi_trips` dataset instead of the previous TPC-H dataset, making the tests more relevant to current data sources.

Tests updated to use https://spice.ai/spiceai/quickstart Spice Cloud  app

**Authentication Handling Improvements**
* Updated all tests and benchmarks to skip cloud authentication tests if `SPICE_API_KEY` is not set or empty, instead of using a hardcoded test API key. This ensures sensitive credentials are handled securely and prevents accidental test execution against the cloud without proper authentication. [[1]](diffhunk://#diff-9a3c852019962d7bcf78e771fe7f1b63ec735e3dc554f907003e4a8915f84f80L23-R25) [[2]](diffhunk://#diff-b045c16cb15dd06c03588480a6a3e04165b4fc09e646902e1f025099309c799dL20-R22) [[3]](diffhunk://#diff-b045c16cb15dd06c03588480a6a3e04165b4fc09e646902e1f025099309c799dL63-R63) [[4]](diffhunk://#diff-b045c16cb15dd06c03588480a6a3e04165b4fc09e646902e1f025099309c799dL235-R233) [[5]](diffhunk://#diff-a9b2510765446a9b372cb60399533fb3f54b822efe09fe0047ef0a99fd77c2f7L38-R40) [[6]](diffhunk://#diff-a9b2510765446a9b372cb60399533fb3f54b822efe09fe0047ef0a99fd77c2f7L65-R65) [[7]](diffhunk://#diff-a1e45d129806a2c1ddddeab3dbc022da3b9f120b260d397f0c1a5fe414afc97dL12-R19)

* Modified the internal query logic in `query.go` to only perform authentication if both `appId` and `apiKey` are provided, allowing unauthenticated queries against local runtimes.

**Test Coverage Enhancements**
* Added new tests in `query_test.go` to explicitly verify that SQL queries work both with and without authentication, including readiness and health checks for local and cloud Spice runtimes.

**Parameterized Query Test Updates**
* Refactored parameterized query tests in `adbc_test.go` to use the `taxi_trips` dataset instead of TPC-H, updating field names, query parameters, and validation logic to match the new schema. This makes the tests more relevant and easier to maintain. [[1]](diffhunk://#diff-9a3c852019962d7bcf78e771fe7f1b63ec735e3dc554f907003e4a8915f84f80L66-L119) [[2]](diffhunk://#diff-9a3c852019962d7bcf78e771fe7f1b63ec735e3dc554f907003e4a8915f84f80L132-R127) [[3]](diffhunk://#diff-9a3c852019962d7bcf78e771fe7f1b63ec735e3dc554f907003e4a8915f84f80L160-L201)

**Code Clean-up**
* Removed the hardcoded `TEST_API_KEY` constant from `query_test.go` and replaced all usages with environment variable checks.

These changes collectively improve security, reliability, and maintainability of tests and benchmarks for both local and cloud environments.
