### PR TITLE
ci: harden the Unix CI job (retry installs + wait for real readiness)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,16 +48,36 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl https://install.spiceai.org | /bin/bash
+          # Retry helper for flaky network installs.
+          retry() {
+            local n
+            for n in 1 2 3; do
+              if "$@"; then return 0; fi
+              echo "::warning::attempt ${n}/3 failed: $*"
+              sleep 5
+            done
+            return 1
+          }
+          retry bash -c 'curl -sSL https://install.spiceai.org | /bin/bash'
           echo "$HOME/.spice/bin" >> $GITHUB_PATH
-          $HOME/.spice/bin/spice install
+          retry "$HOME/.spice/bin/spice" install
 
       - name: Init and start spice app (Unix)
         if: matrix.os != 'windows-latest'
         run: |
+          # Retry helper for flaky network installs.
+          retry() {
+            local n
+            for n in 1 2 3; do
+              if "$@"; then return 0; fi
+              echo "::warning::attempt ${n}/3 failed: $*"
+              sleep 5
+            done
+            return 1
+          }
           spice init spice_qs
           cd spice_qs
-          spice add spiceai/quickstart
+          retry spice add spiceai/quickstart
           spice run &> spice.log &
           # Wait for Spice to be ready
           echo "Waiting for Spice to be ready..."

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -82,7 +82,9 @@ jobs:
           # Wait for Spice to be ready
           echo "Waiting for Spice to be ready..."
           for i in {1..60}; do
-            if curl -s http://localhost:8090/v1/ready 2>/dev/null | grep -q "ready"; then
+            # -f fails on non-2xx; /v1/ready returns 200 only once datasets are
+            # loaded. (A substring `grep "ready"` also matches "not ready".)
+            if curl -fs http://localhost:8090/v1/ready >/dev/null 2>&1; then
               echo "Spice is ready!"
               break
             fi


### PR DESCRIPTION
## Summary

Two sources of intermittent red builds in the Unix (Linux/macOS) CI jobs, both unrelated to the change under test:

**1. Un-retried network installs.** `curl https://install.spiceai.org | bash`, `spice install`, and `spice add spiceai/quickstart` had no retry, so a transient bad download (a truncated/HTML response piped to bash → `syntax error near unexpected token '('`) failed the whole job.

**2. Premature readiness.** The readiness loop used `curl … | grep -q "ready"`, but the substring `"ready"` also matches the runtime's `"not ready"` response — so tests could start before the accelerated datasets finished loading, intermittently failing with 0-row results (e.g. `TestADBCLocalParameterizedQuery` "expected at least 1 row, got 0").

## Change

- Wrap the network installs in a 3-attempt/5s-backoff `retry` helper (mirroring the Windows/WSL job).
- Replace the readiness `grep` with `curl -fs http://localhost:8090/v1/ready`, which only succeeds on a 2xx response (returned once datasets are loaded) — matching the WSL job's check.

Diff is limited to the two Unix steps in `.github/workflows/go.yml`. No behavior change on the happy path.