### PR TITLE
feat: add RuntimeStatus for per-component runtime status

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,31 @@ if !spice.IsSpiceReady(ctx) {
 - `IsSpiceHealthy(ctx)` - Calls `/health` endpoint (unauthenticated)
 - `IsSpiceReady(ctx)` - Calls `/v1/ready` endpoint (requires API key)
 
+### Runtime Status
+
+`IsSpiceReady` collapses the whole runtime into a single boolean. When you need to know
+*which* component is not ready, use `RuntimeStatus` to get per-connection detail:
+
+```go
+details, err := spice.RuntimeStatus(ctx)
+if err != nil {
+    log.Fatalf("error getting runtime status: %v", err)
+}
+
+for _, d := range details {
+    fmt.Printf("%s (%s): %s\n", d.Name, d.Endpoint, d.Status)
+}
+// http (127.0.0.1:8090): Ready
+// flight (127.0.0.1:50051): Ready
+// metrics (N/A): Disabled
+// opentelemetry (127.0.0.1:50051): Ready
+```
+
+Each `ConnectionDetails` carries the component `Name` (`http`, `flight`, `metrics` or
+`opentelemetry`), its `Endpoint`, and its `Status` — one of `Initializing`, `Ready`,
+`Disabled`, `Error`, `Refreshing`, `ShuttingDown` or `NotLoaded`. `d.IsReady()` is a
+shorthand for `d.Status == ComponentStatusReady`.
+
 ## Example
 
 Run `go run .` to execute a sample query and print the results to the console.

--- a/status.go
+++ b/status.go
@@ -63,7 +63,7 @@ func (c *SpiceClient) RuntimeStatus(ctx context.Context) ([]ConnectionDetails, e
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET %s failed with status=%d", url, resp.StatusCode)
+		return nil, fmt.Errorf("GET %s failed with status=%d %s", url, resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 
 	var details []ConnectionDetails

--- a/status.go
+++ b/status.go
@@ -1,0 +1,75 @@
+package gospice
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// ComponentStatus is the state of a single runtime component.
+type ComponentStatus string
+
+const (
+	ComponentStatusInitializing ComponentStatus = "Initializing"
+	ComponentStatusReady        ComponentStatus = "Ready"
+	ComponentStatusDisabled     ComponentStatus = "Disabled"
+	ComponentStatusError        ComponentStatus = "Error"
+	ComponentStatusRefreshing   ComponentStatus = "Refreshing"
+	ComponentStatusShuttingDown ComponentStatus = "ShuttingDown"
+	ComponentStatusNotLoaded    ComponentStatus = "NotLoaded"
+)
+
+// ConnectionDetails describes the status of one runtime connection.
+type ConnectionDetails struct {
+	// Name of the connection, one of "http", "flight", "metrics" or "opentelemetry".
+	Name string `json:"name"`
+	// Endpoint the connection is served on, or "N/A" when the component is disabled.
+	Endpoint string `json:"endpoint"`
+	// Status of the component.
+	Status ComponentStatus `json:"status"`
+}
+
+// IsReady reports whether the component is ready to accept connections.
+func (d ConnectionDetails) IsReady() bool {
+	return d.Status == ComponentStatusReady
+}
+
+// RuntimeStatus returns the status of each runtime connection.
+//
+// Unlike IsSpiceReady, which reports a single boolean for the whole runtime, this
+// reports per-component state and so can distinguish a runtime that is still
+// initializing from one whose Flight endpoint is failing.
+func (c *SpiceClient) RuntimeStatus(ctx context.Context) ([]ConnectionDetails, error) {
+	url := fmt.Sprintf("%s/v1/status", c.baseHttpUrl)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	req = req.WithContext(c.traceHttpRequest(ctx, "RuntimeStatus", req))
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("user-agent", c.userAgent)
+	if c.apiKey != "" {
+		req.Header.Set("X-API-Key", c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s failed with status=%d", url, resp.StatusCode)
+	}
+
+	var details []ConnectionDetails
+	if err := json.NewDecoder(resp.Body).Decode(&details); err != nil {
+		return nil, fmt.Errorf("error decoding runtime status response: %w", err)
+	}
+
+	return details, nil
+}

--- a/status_test.go
+++ b/status_test.go
@@ -4,16 +4,21 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
 func TestRuntimeStatus(t *testing.T) {
 	tests := []struct {
-		name       string
+		name string
+		// statusCode and body are what the stub runtime returns.
 		statusCode int
 		body       string
 		wantErr    bool
-		want       []ConnectionDetails
+		// wantErrContains, when set, must appear in the error message so a caller can
+		// tell 401 from 500 without decoding the numeric code themselves.
+		wantErrContains string
+		want            []ConnectionDetails
 	}{
 		{
 			name:       "all components reported",
@@ -40,10 +45,18 @@ func TestRuntimeStatus(t *testing.T) {
 			},
 		},
 		{
-			name:       "non-200 is an error",
-			statusCode: http.StatusInternalServerError,
-			body:       "boom",
-			wantErr:    true,
+			name:            "non-200 is an error naming the status",
+			statusCode:      http.StatusInternalServerError,
+			body:            "boom",
+			wantErr:         true,
+			wantErrContains: "status=500 Internal Server Error",
+		},
+		{
+			name:            "unauthorized is distinguishable from a server error",
+			statusCode:      http.StatusUnauthorized,
+			body:            "no api key",
+			wantErr:         true,
+			wantErrContains: "status=401 Unauthorized",
 		},
 		{
 			name:       "malformed body is an error",
@@ -80,6 +93,9 @@ func TestRuntimeStatus(t *testing.T) {
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected an error, got nil")
+				}
+				if tt.wantErrContains != "" && !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrContains)
 				}
 				return
 			}

--- a/status_test.go
+++ b/status_test.go
@@ -1,0 +1,121 @@
+package gospice
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRuntimeStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    bool
+		want       []ConnectionDetails
+	}{
+		{
+			name:       "all components reported",
+			statusCode: http.StatusOK,
+			body: `[
+				{"name":"http","endpoint":"127.0.0.1:8090","status":"Ready"},
+				{"name":"flight","endpoint":"127.0.0.1:50051","status":"Ready"},
+				{"name":"metrics","endpoint":"N/A","status":"Disabled"},
+				{"name":"opentelemetry","endpoint":"127.0.0.1:50051","status":"Ready"}
+			]`,
+			want: []ConnectionDetails{
+				{Name: "http", Endpoint: "127.0.0.1:8090", Status: ComponentStatusReady},
+				{Name: "flight", Endpoint: "127.0.0.1:50051", Status: ComponentStatusReady},
+				{Name: "metrics", Endpoint: "N/A", Status: ComponentStatusDisabled},
+				{Name: "opentelemetry", Endpoint: "127.0.0.1:50051", Status: ComponentStatusReady},
+			},
+		},
+		{
+			name:       "component still initializing",
+			statusCode: http.StatusOK,
+			body:       `[{"name":"flight","endpoint":"127.0.0.1:50051","status":"Initializing"}]`,
+			want: []ConnectionDetails{
+				{Name: "flight", Endpoint: "127.0.0.1:50051", Status: ComponentStatusInitializing},
+			},
+		},
+		{
+			name:       "non-200 is an error",
+			statusCode: http.StatusInternalServerError,
+			body:       "boom",
+			wantErr:    true,
+		},
+		{
+			name:       "malformed body is an error",
+			statusCode: http.StatusOK,
+			body:       `{"not":"an array"}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/status" {
+					t.Errorf("got path %q, want /v1/status", r.URL.Path)
+				}
+				if r.Method != http.MethodGet {
+					t.Errorf("got method %q, want GET", r.Method)
+				}
+				if ua := r.Header.Get("user-agent"); ua == "" {
+					t.Error("user-agent header was not set")
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			spice := NewSpiceClient()
+			defer func() { _ = spice.Close() }()
+			if err := WithHttpAddress(srv.URL)(spice); err != nil {
+				t.Fatalf("error setting http address: %v", err)
+			}
+
+			got, err := spice.RuntimeStatus(context.Background())
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d components, want %d", len(got), len(tt.want))
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("component %d: got %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestConnectionDetailsIsReady(t *testing.T) {
+	tests := []struct {
+		status ComponentStatus
+		want   bool
+	}{
+		{ComponentStatusReady, true},
+		{ComponentStatusInitializing, false},
+		{ComponentStatusDisabled, false},
+		{ComponentStatusError, false},
+		{ComponentStatusNotLoaded, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			d := ConnectionDetails{Name: "flight", Status: tt.status}
+			if got := d.IsReady(); got != tt.want {
+				t.Errorf("IsReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds `RuntimeStatus(ctx)`, wrapping `GET /v1/status`. It returns a
`[]ConnectionDetails` — one entry per runtime connection (`http`, `flight`,
`metrics`, `opentelemetry`) with that component's endpoint and status.

## Why

`IsSpiceReady` reduces the whole runtime to one boolean, so when it returns
false there is no way to find out *which* component is not ready without
hand-rolling an HTTP call. `/v1/status` reports that per component, and no
Spice SDK currently exposes it — this is the first.

Statuses map to the runtime's `ComponentStatus`: `Initializing`, `Ready`,
`Disabled`, `Error`, `Refreshing`, `ShuttingDown`, `NotLoaded`. The endpoint
needs no cluster mode or extra configuration, so this works on a default
`spice run`.

Part of aligning runtime health/status coverage across the Spice SDKs.

## Verification

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -run 'TestRuntimeStatus|TestConnectionDetailsIsReady' ./...` — new unit tests pass
- [x] `gofmt -l .` clean
- [ ] Integration tests — not run (no live runtime available in this environment)

The new tests are hermetic: they stand up an `httptest` server rather than
requiring `spice run`, so they cover the decode path, the non-200 path, and the
malformed-body path in CI without external services.