### PR TITLE
feat: add Search for vector, keyword, and hybrid search

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -77,7 +77,22 @@ jobs:
           }
           spice init spice_qs
           cd spice_qs
-          retry spice add spiceai/quickstart
+          # Define the dataset inline instead of `spice add spiceai/quickstart`.
+          # Fetching it from the Spicepod registry makes every PR depend on a
+          # remote service; when that service began returning a non-zip body,
+          # every run failed at "Failed to extract Spicepod archive: Could not
+          # find EOCD". This is the dataset spiceai/quickstart defines.
+          cat >> spicepod.yaml <<'YAML'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          YAML
           spice run &> spice.log &
           # Wait for Spice to be ready
           echo "Waiting for Spice to be ready..."
@@ -150,7 +165,22 @@ jobs:
           # Start a quickstart runtime.
           spice init spice_qs
           cd spice_qs
-          retry spice add spiceai/quickstart
+          # Define the dataset inline instead of `spice add spiceai/quickstart`.
+          # Fetching it from the Spicepod registry makes every PR depend on a
+          # remote service; when that service began returning a non-zip body,
+          # every run failed at "Failed to extract Spicepod archive: Could not
+          # find EOCD". This is the dataset spiceai/quickstart defines.
+          cat >> spicepod.yaml <<'YAML'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          YAML
           nohup spice run > spice.log 2>&1 &
           cd ..
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,55 @@ The `*AsyncQuery` handle provides:
 
 For synchronous, real-time streaming queries, use `Sql` / `SqlWithParams` instead.
 
+## Search
+
+`Search` runs vector similarity, keyword, and hybrid search against datasets that have an
+embedding column and a loaded embedding model.
+
+```go
+resp, err := spice.Search(context.Background(), &gospice.SearchRequest{
+    Text:     "tickets to Tokyo",
+    Datasets: []string{"app_messages"},
+    Limit:    3,
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Printf("%d matches in %dms\n", len(resp.Results), resp.DurationMs)
+for _, match := range resp.Results {
+    fmt.Println(match.Dataset, match.Score, match.PrimaryKey, match.Matches)
+}
+```
+
+Only `Text` is required. `Datasets` restricts the search — leave it empty to search every
+dataset with an embedding column. `Limit` caps matches per dataset, `Where` applies an SQL
+predicate before the search, and `AdditionalColumns` names extra columns to return:
+
+```go
+resp, err := spice.Search(ctx, &gospice.SearchRequest{
+    Text:              "tickets to Tokyo",
+    Datasets:          []string{"app_messages"},
+    Where:             "city = 'Tokyo'",
+    AdditionalColumns: []string{"timestamp"},
+})
+```
+
+Setting `Keywords` pre-filters the embedding column with a lexical search before the vector
+search runs, making the search hybrid:
+
+```go
+resp, err := spice.Search(ctx, &gospice.SearchRequest{
+    Text:     "tickets to Tokyo",
+    Keywords: []string{"plane", "tickets"},
+})
+```
+
+Each `SearchMatch` carries the `Dataset` it was found in, its similarity `Score`, the matched
+column values in `Matches`, the row's `PrimaryKey`, the columns requested via
+`AdditionalColumns` in `Data`, and any `Metadata`. The runtime omits the last three when
+empty, so they decode to `nil` — reading a key from a nil map is safe in Go.
+
 ## Health Checks
 
 gospice v9 provides health check methods to verify Spice instance status before executing queries:

--- a/search.go
+++ b/search.go
@@ -135,9 +135,14 @@ func (c *SpiceClient) Search(ctx context.Context, req *SearchRequest) (*SearchRe
 
 	httpReq = httpReq.WithContext(c.traceHttpRequest(ctx, "Search", httpReq))
 
-	httpReq.Header.Set("X-API-Key", c.apiKey)
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("user-agent", c.userAgent)
+	// Only send the key when there is one — an empty X-API-Key reads as a
+	// supplied-but-invalid credential to auth middleware, which is different
+	// from omitting the header. Matches IsSpiceReady in client.go.
+	if c.apiKey != "" {
+		httpReq.Header.Set("X-API-Key", c.apiKey)
+	}
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {

--- a/search.go
+++ b/search.go
@@ -1,0 +1,146 @@
+package gospice
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// SearchRequest describes a search against one or more datasets.
+//
+// Text is required. Every other field is optional: when Datasets is empty the
+// runtime searches every dataset that has an embedding column, and when Limit
+// is zero the runtime applies its own default.
+type SearchRequest struct {
+	// Text is the query to find similar documents for.
+	Text string `json:"text"`
+
+	// Datasets restricts the search to the named datasets. Empty means every
+	// dataset with an embedding column and a loaded embedding model.
+	Datasets []string `json:"datasets,omitempty"`
+
+	// Limit caps the number of matches returned per dataset.
+	Limit int `json:"limit,omitempty"`
+
+	// Where is an SQL predicate applied before the search, without the WHERE
+	// keyword — for example `city = 'Tokyo'`.
+	Where string `json:"where,omitempty"`
+
+	// AdditionalColumns names extra dataset columns to return. A column that is
+	// part of the dataset's primary key is returned in SearchMatch.PrimaryKey
+	// rather than SearchMatch.Data.
+	AdditionalColumns []string `json:"additional_columns,omitempty"`
+
+	// Keywords pre-filters the embedding column with a lexical search before the
+	// vector search runs, producing a hybrid search.
+	Keywords []string `json:"keywords,omitempty"`
+}
+
+// SearchMatch is a single document matched by a search.
+type SearchMatch struct {
+	// Dataset is the dataset the match was found in.
+	Dataset string `json:"dataset"`
+
+	// Score is the similarity of the match to the query text. Higher is closer.
+	Score float64 `json:"_score"`
+
+	// Matches holds the matched values of each searched column.
+	Matches map[string][]any `json:"matches,omitempty"`
+
+	// PrimaryKey identifies the matched row. Empty unless the dataset declares a
+	// primary key.
+	PrimaryKey map[string]any `json:"primary_key,omitempty"`
+
+	// Data holds the columns requested via SearchRequest.AdditionalColumns.
+	Data map[string]any `json:"data,omitempty"`
+
+	// Metadata holds any additional metadata the runtime attached to the match.
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// SearchResponse is the result of a search.
+type SearchResponse struct {
+	// Results are the matches, ordered by descending score.
+	Results []SearchMatch `json:"results"`
+
+	// DurationMs is how long the runtime took to run the search.
+	DurationMs int64 `json:"duration_ms"`
+}
+
+// searchErrorResponse is the runtime's error body for a failed search.
+type searchErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// Search runs a vector similarity, keyword, or hybrid search against datasets
+// that have an embedding column and a loaded embedding model.
+//
+// Set SearchRequest.Keywords to pre-filter with a lexical search before the
+// vector search, which makes the search hybrid.
+//
+//	resp, err := spice.Search(ctx, &gospice.SearchRequest{
+//		Text:     "tickets to Tokyo",
+//		Datasets: []string{"app_messages"},
+//		Limit:    3,
+//	})
+//	if err != nil {
+//		return err
+//	}
+//	for _, match := range resp.Results {
+//		fmt.Println(match.Dataset, match.Score, match.Matches)
+//	}
+func (c *SpiceClient) Search(ctx context.Context, req *SearchRequest) (*SearchResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("search request is required")
+	}
+	if req.Text == "" {
+		return nil, fmt.Errorf("search request Text is required")
+	}
+
+	jsonData, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling SearchRequest: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/v1/search", c.baseHttpUrl)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	httpReq = httpReq.WithContext(c.traceHttpRequest(ctx, "Search", httpReq))
+
+	httpReq.Header.Set("X-API-Key", c.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("user-agent", c.userAgent)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading search response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp searchErrorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error != "" {
+			return nil, fmt.Errorf("search failed with status=%d: %s", resp.StatusCode, errResp.Error)
+		}
+		return nil, fmt.Errorf("POST %s failed with status=%d", url, resp.StatusCode)
+	}
+
+	var searchResp SearchResponse
+	if err := json.Unmarshal(respBody, &searchResp); err != nil {
+		return nil, fmt.Errorf("error parsing search response: %w", err)
+	}
+
+	return &searchResp, nil
+}

--- a/search.go
+++ b/search.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // SearchRequest describes a search against one or more datasets.
@@ -70,9 +71,29 @@ type SearchResponse struct {
 	DurationMs int64 `json:"duration_ms"`
 }
 
-// searchErrorResponse is the runtime's error body for a failed search.
+// searchErrorResponse is the runtime's JSON error body for a failed search.
 type searchErrorResponse struct {
 	Error string `json:"error"`
+}
+
+// searchErrorMessage extracts the message to report from a failed search response.
+//
+// The runtime answers some failures with a JSON {"error": "..."} body and others —
+// "Search cannot be run on X because it has no embeddings or full text search
+// indexes", for instance — with plain text, so both shapes have to be handled or the
+// part that tells the caller what to fix is lost.
+func searchErrorMessage(body []byte) string {
+	trimmed := strings.TrimSpace(string(body))
+	if trimmed == "" {
+		return "(no response body)"
+	}
+
+	var errResp searchErrorResponse
+	if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
+		return errResp.Error
+	}
+
+	return trimmed
 }
 
 // Search runs a vector similarity, keyword, or hybrid search against datasets
@@ -130,11 +151,7 @@ func (c *SpiceClient) Search(ctx context.Context, req *SearchRequest) (*SearchRe
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		var errResp searchErrorResponse
-		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error != "" {
-			return nil, fmt.Errorf("search failed with status=%d: %s", resp.StatusCode, errResp.Error)
-		}
-		return nil, fmt.Errorf("POST %s failed with status=%d", url, resp.StatusCode)
+		return nil, fmt.Errorf("search failed with status=%d: %s", resp.StatusCode, searchErrorMessage(respBody))
 	}
 
 	var searchResp SearchResponse

--- a/search_test.go
+++ b/search_test.go
@@ -127,6 +127,46 @@ func TestSearchMethodAndPath(t *testing.T) {
 	}
 }
 
+func TestSearchApiKeyHeader(t *testing.T) {
+	// An empty X-API-Key is not the same as no X-API-Key: auth middleware can
+	// read the former as a supplied-but-invalid credential.
+	tests := []struct {
+		name   string
+		apiKey string
+		want   string
+	}{
+		{name: "no key omits the header", apiKey: "", want: ""},
+		{name: "key is sent", apiKey: "test-key", want: "test-key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			var present bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, present = r.Header["X-Api-Key"]
+				got = r.Header.Get("X-API-Key")
+				_, _ = w.Write([]byte(`{"results":[],"duration_ms":0}`))
+			}))
+			defer srv.Close()
+
+			c := newTestSearchClient(srv)
+			c.apiKey = tt.apiKey
+
+			if _, err := c.Search(context.Background(), &SearchRequest{Text: "x"}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.want == "" && present {
+				t.Error("X-API-Key should be absent when no key is configured")
+			}
+			if got != tt.want {
+				t.Errorf("X-API-Key = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSearchResponseDecoding(t *testing.T) {
 	// A response in the runtime's wire format: the score is `_score`, and
 	// data/primary_key/metadata are omitted entirely when empty.

--- a/search_test.go
+++ b/search_test.go
@@ -1,0 +1,248 @@
+package gospice
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestSearchClient returns a client pointed at srv, without dialing Flight.
+func newTestSearchClient(srv *httptest.Server) *SpiceClient {
+	c := NewSpiceClient()
+	c.baseHttpUrl = srv.URL
+	return c
+}
+
+func TestSearchRequestEncoding(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *SearchRequest
+		want map[string]any
+	}{
+		{
+			name: "text only omits optional fields",
+			req:  &SearchRequest{Text: "tickets to Tokyo"},
+			want: map[string]any{"text": "tickets to Tokyo"},
+		},
+		{
+			name: "datasets and limit",
+			req: &SearchRequest{
+				Text:     "tickets to Tokyo",
+				Datasets: []string{"app_messages"},
+				Limit:    3,
+			},
+			want: map[string]any{
+				"text":     "tickets to Tokyo",
+				"datasets": []any{"app_messages"},
+				"limit":    float64(3),
+			},
+		},
+		{
+			name: "where predicate uses the wire name",
+			req: &SearchRequest{
+				Text:  "tickets",
+				Where: "city = 'Tokyo'",
+			},
+			want: map[string]any{
+				"text":  "tickets",
+				"where": "city = 'Tokyo'",
+			},
+		},
+		{
+			name: "keywords make the search hybrid",
+			req: &SearchRequest{
+				Text:              "tickets",
+				AdditionalColumns: []string{"timestamp"},
+				Keywords:          []string{"plane", "tickets"},
+			},
+			want: map[string]any{
+				"text":               "tickets",
+				"additional_columns": []any{"timestamp"},
+				"keywords":           []any{"plane", "tickets"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("error reading request body: %v", err)
+				}
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Errorf("error unmarshaling request body: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"results":[],"duration_ms":1}`))
+			}))
+			defer srv.Close()
+
+			if _, err := newTestSearchClient(srv).Search(context.Background(), tt.req); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != len(tt.want) {
+				t.Errorf("encoded %d fields, want %d: got %v", len(got), len(tt.want), got)
+			}
+			for k, want := range tt.want {
+				gotVal, ok := got[k]
+				if !ok {
+					t.Errorf("missing field %q in %v", k, got)
+					continue
+				}
+				if gotJSON, _ := json.Marshal(gotVal); string(gotJSON) != mustJSON(t, want) {
+					t.Errorf("field %q = %v, want %v", k, gotVal, want)
+				}
+			}
+		})
+	}
+}
+
+func TestSearchMethodAndPath(t *testing.T) {
+	var method, path, contentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method, path, contentType = r.Method, r.URL.Path, r.Header.Get("Content-Type")
+		_, _ = w.Write([]byte(`{"results":[],"duration_ms":0}`))
+	}))
+	defer srv.Close()
+
+	if _, err := newTestSearchClient(srv).Search(context.Background(), &SearchRequest{Text: "x"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if method != http.MethodPost {
+		t.Errorf("method = %q, want POST", method)
+	}
+	if path != "/v1/search" {
+		t.Errorf("path = %q, want /v1/search", path)
+	}
+	if contentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", contentType)
+	}
+}
+
+func TestSearchResponseDecoding(t *testing.T) {
+	// A response in the runtime's wire format: the score is `_score`, and
+	// data/primary_key/metadata are omitted entirely when empty.
+	const body = `{
+		"results": [
+			{
+				"matches": {"message": ["I booked us some tickets"]},
+				"dataset": "app_messages",
+				"primary_key": {"id": "6fd5a215-0881-421d-ace0-b293b83452b5"},
+				"data": {"timestamp": 1724716542},
+				"_score": 0.914321
+			},
+			{
+				"matches": {"message": ["direct to Narita"]},
+				"dataset": "app_messages",
+				"_score": 0.83221
+			}
+		],
+		"duration_ms": 42
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	resp, err := newTestSearchClient(srv).Search(context.Background(), &SearchRequest{Text: "tickets"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.DurationMs != 42 {
+		t.Errorf("DurationMs = %d, want 42", resp.DurationMs)
+	}
+	if len(resp.Results) != 2 {
+		t.Fatalf("got %d results, want 2", len(resp.Results))
+	}
+
+	first := resp.Results[0]
+	if first.Dataset != "app_messages" {
+		t.Errorf("Dataset = %q, want app_messages", first.Dataset)
+	}
+	if first.Score != 0.914321 {
+		t.Errorf("Score = %v, want 0.914321", first.Score)
+	}
+	if got := first.PrimaryKey["id"]; got != "6fd5a215-0881-421d-ace0-b293b83452b5" {
+		t.Errorf("PrimaryKey[id] = %v", got)
+	}
+	if got := first.Data["timestamp"]; got != float64(1724716542) {
+		t.Errorf("Data[timestamp] = %v", got)
+	}
+	if got := first.Matches["message"]; len(got) != 1 || got[0] != "I booked us some tickets" {
+		t.Errorf("Matches[message] = %v", got)
+	}
+
+	// Omitted objects decode to nil, which is safe to read from in Go.
+	second := resp.Results[1]
+	if second.Data != nil {
+		t.Errorf("Data = %v, want nil for an omitted field", second.Data)
+	}
+	if got := second.Data["timestamp"]; got != nil {
+		t.Errorf("reading an omitted map should yield nil, got %v", got)
+	}
+}
+
+func TestSearchValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     *SearchRequest
+		wantErr string
+	}{
+		{name: "nil request", req: nil, wantErr: "search request is required"},
+		{name: "empty text", req: &SearchRequest{}, wantErr: "Text is required"},
+		{name: "empty text with datasets", req: &SearchRequest{Datasets: []string{"a"}}, wantErr: "Text is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Error("request should not reach the runtime when validation fails")
+			}))
+			defer srv.Close()
+
+			_, err := newTestSearchClient(srv).Search(context.Background(), tt.req)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSearchSurfacesRuntimeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"No data sources provided"}`))
+	}))
+	defer srv.Close()
+
+	_, err := newTestSearchClient(srv).Search(context.Background(), &SearchRequest{Text: "x"})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	// The runtime's message is what tells the user what to fix.
+	if !strings.Contains(err.Error(), "No data sources provided") {
+		t.Errorf("error = %q, want it to carry the runtime's message", err.Error())
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("error marshaling %v: %v", v, err)
+	}
+	return string(b)
+}

--- a/search_test.go
+++ b/search_test.go
@@ -222,19 +222,46 @@ func TestSearchValidation(t *testing.T) {
 }
 
 func TestSearchSurfacesRuntimeError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"error":"No data sources provided"}`))
-	}))
-	defer srv.Close()
-
-	_, err := newTestSearchClient(srv).Search(context.Background(), &SearchRequest{Text: "x"})
-	if err == nil {
-		t.Fatal("expected an error")
+	// The runtime answers some failures with JSON and others with plain text. Both
+	// carry the part that tells the caller what to fix, so both must survive.
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "json error body",
+			body: `{"error":"No data sources provided"}`,
+			want: "No data sources provided",
+		},
+		{
+			name: "plain text body",
+			body: "Search cannot be run on nation because it has no embeddings or full text search indexes.",
+			want: "no embeddings or full text search indexes",
+		},
+		{
+			name: "empty body",
+			body: "",
+			want: "(no response body)",
+		},
 	}
-	// The runtime's message is what tells the user what to fix.
-	if !strings.Contains(err.Error(), "No data sources provided") {
-		t.Errorf("error = %q, want it to carry the runtime's message", err.Error())
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			_, err := newTestSearchClient(srv).Search(context.Background(), &SearchRequest{Text: "x"})
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

Adds `SpiceClient.Search`, wrapping the runtime's `POST /v1/search` — vector similarity, keyword, and hybrid search over datasets with an embedding column.

```go
resp, err := spice.Search(ctx, &gospice.SearchRequest{
    Text:     "tickets to Tokyo",
    Datasets: []string{"app_messages"},
    Limit:    3,
})
```

Only `Text` is required. Setting `Keywords` pre-filters the embedding column with a lexical search before the vector search runs, making the search hybrid.

## Why

`/v1/search` works on a default `spice run` and is a distinctive Spice capability, but Go users had no way to reach it short of hand-rolling the HTTP call. spice.js is currently the only SDK that exposes it.

Two wire-format details the types handle so callers don't have to:

- the similarity score is serialized as `_score`, not `score`
- `data`, `primary_key` and `metadata` are omitted entirely when empty, so they decode to `nil` maps — safe to read from in Go

Part of aligning search support across the SDKs.

## Verification

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt` clean
- [x] Unit tests pass — `go test -run TestSearch ./...`, covering request encoding, method/path, response decoding (including omitted objects), validation, and runtime error surfacing. All run against `httptest`, so they need no live runtime.
- [x] Verified against a live `spice run`: the search request reaches `/v1/search`, and a
      failure surfaces the runtime's own message (`"Search cannot be run on <dataset> because it
      has no embeddings or full text search indexes."`) rather than a bare status code
- [ ] A search returning matches was not exercised end to end — that needs a dataset with an
      embedding column and a loaded embedding model, which this environment has no credentials for
