### PR TITLE
ci: define the test dataset inline instead of fetching it from the registry

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -77,7 +77,22 @@ jobs:
           }
           spice init spice_qs
           cd spice_qs
-          retry spice add spiceai/quickstart
+          # Define the dataset inline instead of `spice add spiceai/quickstart`.
+          # Fetching it from the Spicepod registry makes every PR depend on a
+          # remote service; when that service began returning a non-zip body,
+          # every run failed at "Failed to extract Spicepod archive: Could not
+          # find EOCD". This is the dataset spiceai/quickstart defines.
+          cat >> spicepod.yaml <<'YAML'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          YAML
           spice run &> spice.log &
           # Wait for Spice to be ready
           echo "Waiting for Spice to be ready..."
@@ -150,7 +165,22 @@ jobs:
           # Start a quickstart runtime.
           spice init spice_qs
           cd spice_qs
-          retry spice add spiceai/quickstart
+          # Define the dataset inline instead of `spice add spiceai/quickstart`.
+          # Fetching it from the Spicepod registry makes every PR depend on a
+          # remote service; when that service began returning a non-zip body,
+          # every run failed at "Failed to extract Spicepod archive: Could not
+          # find EOCD". This is the dataset spiceai/quickstart defines.
+          cat >> spicepod.yaml <<'YAML'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          YAML
           nohup spice run > spice.log 2>&1 &
           cd ..
 


### PR DESCRIPTION
## What

Replaces `spice add spiceai/quickstart` with the same dataset declared inline in the generated spicepod. Both the Unix and WSL setup steps.

## Why

Every job currently dies before a single test runs:

```
ERROR Invalid argument: Failed to extract Spicepod archive: invalid Zip archive: Could not find EOCD
##[warning]attempt 3/3 failed: spice add spiceai/quickstart
```

The Spicepod registry is returning a body the CLI can't unpack. The retry wrapper doesn't help — all three attempts fail the same way. Nothing about the runtime or the SDK is broken; only the fetch is.

This reproduces off CI too: running `spice add spiceai/quickstart` on a local machine gives the identical error, so it isn't a runner or network quirk.

Pulling a fixture from a remote registry means every PR in this repo depends on that service being healthy. Declaring the dataset inline removes the dependency, and it's the same data `spiceai/quickstart` provides.

Mirrors [spicepy#176](https://github.com/spiceai/spicepy/pull/176), which takes the same approach and is green.

## Verification

Ran the exact spicepod this produces against a local runtime:

```
$ spice init qs && cd qs && cat >> spicepod.yaml <<'YAML' ... YAML
$ spiced
QUERYABLE after 6s
[{"n":2964624}]
```

- [x] `taxi_trips` loads and is queryable within seconds
- [x] Workflow YAML parses, and the heredoc dedents correctly under the `run: |` block scalar — bash receives valid, unindented YAML
- [x] `spice init` emits `version: v2`, so the generated spicepod is on the current version

Note the cloud-backed tests (`tpch.customer`, `eth.recent_blocks`) are unaffected — they authenticate with `SPICE_API_KEY` and don't come from the quickstart pod.