### PR TITLE
feat: add Search for the runtime's /v1/search endpoint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,7 +41,7 @@ jobs:
       # runtime install + integration tests to WSL (see the WSL steps below).
       - name: Unit tests (Windows native)
         if: matrix.os == 'windows-latest'
-        run: go test -v -run 'TestUserAgent|TestPrependedUserAgent|TestInferArrowType|TestAppendValueToBuilder|TestComprehensiveArrowTypes|TestParamType|TestTypedParamInference|TestExtendedArrowTypes' ./...
+        run: go test -v -run 'TestUserAgent|TestPrependedUserAgent|TestInferArrowType|TestAppendValueToBuilder|TestComprehensiveArrowTypes|TestParamType|TestTypedParamInference|TestExtendedArrowTypes|TestSearch' ./...
 
       - name: Install Spice (https://install.spiceai.org) (Linux)
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'

--- a/README.md
+++ b/README.md
@@ -228,6 +228,41 @@ if !spice.IsSpiceReady(ctx) {
 - `IsSpiceHealthy(ctx)` - Calls `/health` endpoint (unauthenticated)
 - `IsSpiceReady(ctx)` - Calls `/v1/ready` endpoint (requires API key)
 
+## Search
+
+`Search` finds documents similar to a piece of text, using the runtime's `/v1/search` endpoint. It runs against datasets that have an embedding column and a loaded embedding model — see [Search & Retrieval](https://docs.spice.ai/features/search-and-retrieval) for how to configure them.
+
+```go
+ctx := context.Background()
+limit := 3
+
+resp, err := spice.Search(ctx, &gospice.SearchRequest{
+    Text:              "tokyo plane tickets",
+    Datasets:          []string{"app_messages"},
+    Limit:             &limit,
+    AdditionalColumns: []string{"timestamp"},
+})
+if err != nil {
+    log.Fatalf("search failed: %v", err)
+}
+
+fmt.Printf("%d matches in %dms\n", len(resp.Results), resp.DurationMs)
+for _, match := range resp.Results {
+    fmt.Println(match.Score, match.Dataset, match.Matches, match.Data)
+}
+```
+
+`SearchRequest` fields:
+
+- `Text` (required) - The text to find similar documents for.
+- `Datasets` - Datasets to search. Leave empty to search every searchable dataset.
+- `Limit` - Maximum matches to return per dataset.
+- `Where` - A SQL predicate filtering candidate rows, without the leading `WHERE` — for example `"user_id = 42"`.
+- `AdditionalColumns` - Extra columns to return with each match. Primary key columns are returned in `PrimaryKey`, the rest in `Data`.
+- `Keywords` - Keywords for the lexical pass of a hybrid search, which the runtime combines with the vector scores into a single ranking.
+
+Each `SearchMatch` carries `Dataset`, `Score` (higher is more similar), `Matches` (matched values keyed by source column — a slice per column, since one column can contribute several chunks to a match), `PrimaryKey`, `Data`, and `Metadata`.
+
 ## Example
 
 Run `go run .` to execute a sample query and print the results to the console.

--- a/search.go
+++ b/search.go
@@ -39,6 +39,11 @@ type SearchRequest struct {
 }
 
 // SearchMatch is a single document matched by Search.
+//
+// The runtime omits primary_key, data and metadata from a match that has
+// none, so PrimaryKey, Data and Metadata are nil rather than empty in that
+// case. Reading from a nil map is safe and reports no entries; assigning into
+// one panics, so allocate before writing.
 type SearchMatch struct {
 	// Dataset is the dataset the match was found in.
 	Dataset string `json:"dataset"`
@@ -51,14 +56,16 @@ type SearchMatch struct {
 	// to a single match.
 	Matches map[string][]any `json:"matches"`
 
-	// PrimaryKey identifies the matched row. Empty when the dataset declares
-	// no primary key.
+	// PrimaryKey identifies the matched row. Nil when the dataset declares no
+	// primary key.
 	PrimaryKey map[string]any `json:"primary_key"`
 
-	// Data holds any AdditionalColumns that were requested.
+	// Data holds any AdditionalColumns that were requested. Nil when none were
+	// requested.
 	Data map[string]any `json:"data"`
 
-	// Metadata holds extra per-match metadata the runtime attached.
+	// Metadata holds extra per-match metadata the runtime attached. Nil when
+	// it attached none.
 	Metadata map[string]any `json:"metadata"`
 }
 

--- a/search.go
+++ b/search.go
@@ -1,0 +1,132 @@
+package gospice
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// SearchRequest describes a search against the runtime's /v1/search endpoint.
+//
+// Only Text is required. Supplying Keywords adds a lexical pass, which the
+// runtime combines with the vector scores into a single hybrid ranking.
+type SearchRequest struct {
+	// Text is the text to find similar documents for. Required.
+	Text string `json:"text"`
+
+	// Datasets restricts the search to the named datasets. When empty, the
+	// runtime searches every searchable dataset.
+	Datasets []string `json:"datasets,omitempty"`
+
+	// Limit caps the number of matches returned per dataset. When nil, the
+	// runtime applies its own default.
+	Limit *int `json:"limit,omitempty"`
+
+	// Where is a SQL predicate filtering candidate rows, without the leading
+	// WHERE - for example "user_id = 42".
+	Where *string `json:"where,omitempty"`
+
+	// AdditionalColumns names extra columns to return with each match. A
+	// primary key column is returned in SearchMatch.PrimaryKey, the rest in
+	// SearchMatch.Data.
+	AdditionalColumns []string `json:"additional_columns,omitempty"`
+
+	// Keywords drives the lexical pass of a hybrid search.
+	Keywords []string `json:"keywords,omitempty"`
+}
+
+// SearchMatch is a single document matched by Search.
+type SearchMatch struct {
+	// Dataset is the dataset the match was found in.
+	Dataset string `json:"dataset"`
+
+	// Score is the match's similarity to the query. Higher is more similar.
+	Score float64 `json:"_score"`
+
+	// Matches holds the matched values keyed by the column they came from.
+	// Each value is a slice because one column can contribute several chunks
+	// to a single match.
+	Matches map[string][]any `json:"matches"`
+
+	// PrimaryKey identifies the matched row. Empty when the dataset declares
+	// no primary key.
+	PrimaryKey map[string]any `json:"primary_key"`
+
+	// Data holds any AdditionalColumns that were requested.
+	Data map[string]any `json:"data"`
+
+	// Metadata holds extra per-match metadata the runtime attached.
+	Metadata map[string]any `json:"metadata"`
+}
+
+// SearchResponse is the result of a single Search call.
+type SearchResponse struct {
+	// Results are the matches, ordered by descending score.
+	Results []SearchMatch `json:"results"`
+
+	// DurationMs is how long the runtime reported the search took.
+	DurationMs uint64 `json:"duration_ms"`
+}
+
+// Search finds documents similar to req.Text by calling the runtime's
+// /v1/search endpoint.
+//
+// It runs against datasets that have an embedding column and a loaded
+// embedding model. See https://docs.spice.ai/features/search-and-retrieval for
+// how to configure them.
+func (c *SpiceClient) Search(ctx context.Context, req *SearchRequest) (*SearchResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("req is required")
+	}
+	if req.Text == "" {
+		return nil, fmt.Errorf("req.Text is required and must be a non-empty search string")
+	}
+	if req.Limit != nil && *req.Limit < 1 {
+		return nil, fmt.Errorf("req.Limit must be greater than 0, got %d", *req.Limit)
+	}
+
+	jsonData, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling SearchRequest: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/v1/search", c.baseHttpUrl)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	httpReq = httpReq.WithContext(c.traceHttpRequest(ctx, "Search", httpReq))
+
+	httpReq.Header.Set("X-API-Key", c.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("user-agent", c.userAgent)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response from POST %s: %w", url, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// The runtime explains search failures in a plain-text body ("No data
+		// sources provided"). Surface it rather than only the status code.
+		return nil, fmt.Errorf("POST %s failed with status=%d: %s", url, resp.StatusCode, bytes.TrimSpace(respBody))
+	}
+
+	var searchResp SearchResponse
+	if err := json.Unmarshal(respBody, &searchResp); err != nil {
+		return nil, fmt.Errorf("error decoding response from POST %s: %w", url, err)
+	}
+
+	return &searchResp, nil
+}

--- a/search_test.go
+++ b/search_test.go
@@ -1,0 +1,251 @@
+package gospice
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newSearchTestClient returns a client pointed at handler, without dialing
+// Flight - Search only uses the HTTP control plane.
+func newSearchTestClient(t *testing.T, handler http.HandlerFunc) *SpiceClient {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	spice := NewSpiceClient()
+	if err := WithHttpAddress(server.URL)(spice); err != nil {
+		t.Fatalf("error setting http address: %v", err)
+	}
+	return spice
+}
+
+func TestSearchRequestEncoding(t *testing.T) {
+	limit := 3
+	where := "user_id = 42"
+
+	tests := []struct {
+		name string
+		req  *SearchRequest
+		want map[string]any
+	}{
+		{
+			name: "text only",
+			req:  &SearchRequest{Text: "tokyo"},
+			want: map[string]any{"text": "tokyo"},
+		},
+		{
+			name: "all options",
+			req: &SearchRequest{
+				Text:              "tokyo",
+				Datasets:          []string{"app_messages"},
+				Limit:             &limit,
+				Where:             &where,
+				AdditionalColumns: []string{"timestamp"},
+				Keywords:          []string{"plane", "tickets"},
+			},
+			want: map[string]any{
+				"text":               "tokyo",
+				"datasets":           []any{"app_messages"},
+				"limit":              float64(3),
+				"where":              "user_id = 42",
+				"additional_columns": []any{"timestamp"},
+				"keywords":           []any{"plane", "tickets"},
+			},
+		},
+		{
+			// The runtime rejects an empty dataset list with a 400, so an empty
+			// slice must be omitted rather than sent.
+			name: "empty datasets omitted",
+			req:  &SearchRequest{Text: "tokyo", Datasets: []string{}},
+			want: map[string]any{"text": "tokyo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got map[string]any
+
+			spice := newSearchTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("error reading request body: %v", err)
+				}
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Errorf("error decoding request body: %v", err)
+				}
+				_, _ = io.WriteString(w, `{"results":[],"duration_ms":0}`)
+			})
+
+			if _, err := spice.Search(context.Background(), tt.req); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			gotJSON, _ := json.Marshal(got)
+			wantJSON, _ := json.Marshal(tt.want)
+			if string(gotJSON) != string(wantJSON) {
+				t.Errorf("request body = %s, want %s", gotJSON, wantJSON)
+			}
+		})
+	}
+}
+
+func TestSearchRequestPath(t *testing.T) {
+	var gotPath, gotMethod string
+
+	spice := newSearchTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		_, _ = io.WriteString(w, `{"results":[],"duration_ms":0}`)
+	})
+
+	if _, err := spice.Search(context.Background(), &SearchRequest{Text: "tokyo"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotPath != "/v1/search" {
+		t.Errorf("path = %q, want %q", gotPath, "/v1/search")
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want %q", gotMethod, http.MethodPost)
+	}
+}
+
+func TestSearchResponseDecoding(t *testing.T) {
+	body := `{
+		"results": [
+			{
+				"matches": {"message": ["I booked us some tickets", "direct to Narita"]},
+				"dataset": "app_messages",
+				"primary_key": {"id": "6fd5a215"},
+				"data": {"timestamp": 1724716542},
+				"metadata": {"chunk": 2},
+				"_score": 0.914321
+			},
+			{
+				"matches": {"message": ["we're sitting together"]},
+				"dataset": "app_messages",
+				"_score": 0.787654
+			}
+		],
+		"duration_ms": 42
+	}`
+
+	spice := newSearchTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, body)
+	})
+
+	resp, err := spice.Search(context.Background(), &SearchRequest{Text: "tokyo"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.DurationMs != 42 {
+		t.Errorf("DurationMs = %d, want 42", resp.DurationMs)
+	}
+	if len(resp.Results) != 2 {
+		t.Fatalf("len(Results) = %d, want 2", len(resp.Results))
+	}
+
+	first := resp.Results[0]
+	if first.Dataset != "app_messages" {
+		t.Errorf("Dataset = %q, want %q", first.Dataset, "app_messages")
+	}
+	if first.Score != 0.914321 {
+		t.Errorf("Score = %v, want 0.914321", first.Score)
+	}
+	// One column can contribute several chunks to a single match.
+	if len(first.Matches["message"]) != 2 {
+		t.Errorf("len(Matches[message]) = %d, want 2", len(first.Matches["message"]))
+	}
+	if first.PrimaryKey["id"] != "6fd5a215" {
+		t.Errorf("PrimaryKey[id] = %v, want %q", first.PrimaryKey["id"], "6fd5a215")
+	}
+	if first.Data["timestamp"] != float64(1724716542) {
+		t.Errorf("Data[timestamp] = %v, want 1724716542", first.Data["timestamp"])
+	}
+	if first.Metadata["chunk"] != float64(2) {
+		t.Errorf("Metadata[chunk] = %v, want 2", first.Metadata["chunk"])
+	}
+
+	// The runtime omits data, primary_key, and metadata when they are empty.
+	second := resp.Results[1]
+	if len(second.PrimaryKey) != 0 || len(second.Data) != 0 || len(second.Metadata) != 0 {
+		t.Errorf("omitted fields should decode empty, got PrimaryKey=%v Data=%v Metadata=%v",
+			second.PrimaryKey, second.Data, second.Metadata)
+	}
+}
+
+func TestSearchValidation(t *testing.T) {
+	zero := 0
+	negative := -1
+
+	tests := []struct {
+		name    string
+		req     *SearchRequest
+		wantErr string
+	}{
+		{name: "nil request", req: nil, wantErr: "req is required"},
+		{name: "empty text", req: &SearchRequest{}, wantErr: "req.Text is required"},
+		{name: "zero limit", req: &SearchRequest{Text: "tokyo", Limit: &zero}, wantErr: "greater than 0"},
+		{name: "negative limit", req: &SearchRequest{Text: "tokyo", Limit: &negative}, wantErr: "greater than 0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			spice := newSearchTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				_, _ = io.WriteString(w, `{"results":[],"duration_ms":0}`)
+			})
+
+			_, err := spice.Search(context.Background(), tt.req)
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+			if called {
+				t.Error("expected no request to be sent")
+			}
+		})
+	}
+}
+
+func TestSearchErrorSurfacesRuntimeMessage(t *testing.T) {
+	spice := newSearchTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, "No data sources provided")
+	})
+
+	_, err := spice.Search(context.Background(), &SearchRequest{Text: "tokyo"})
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "No data sources provided") {
+		t.Errorf("error = %q, want it to carry the runtime's message", err.Error())
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("error = %q, want it to carry the status code", err.Error())
+	}
+}
+
+func TestSearchMalformedResponse(t *testing.T) {
+	spice := newSearchTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "not json")
+	})
+
+	_, err := spice.Search(context.Background(), &SearchRequest{Text: "tokyo"})
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "error decoding response") {
+		t.Errorf("error = %q, want a decode error", err.Error())
+	}
+}

--- a/search_test.go
+++ b/search_test.go
@@ -173,11 +173,23 @@ func TestSearchResponseDecoding(t *testing.T) {
 		t.Errorf("Metadata[chunk] = %v, want 2", first.Metadata["chunk"])
 	}
 
-	// The runtime omits data, primary_key, and metadata when they are empty.
+	// The runtime omits data, primary_key, and metadata from a match that has
+	// none, and an absent JSON key leaves the map nil. Assert nil rather than
+	// len == 0, which would also pass for an allocated empty map and so would
+	// not pin down what a caller actually receives.
 	second := resp.Results[1]
-	if len(second.PrimaryKey) != 0 || len(second.Data) != 0 || len(second.Metadata) != 0 {
-		t.Errorf("omitted fields should decode empty, got PrimaryKey=%v Data=%v Metadata=%v",
-			second.PrimaryKey, second.Data, second.Metadata)
+	if second.PrimaryKey != nil {
+		t.Errorf("omitted primary_key should decode nil, got %v", second.PrimaryKey)
+	}
+	if second.Data != nil {
+		t.Errorf("omitted data should decode nil, got %v", second.Data)
+	}
+	if second.Metadata != nil {
+		t.Errorf("omitted metadata should decode nil, got %v", second.Metadata)
+	}
+	// A nil map is still safe to read, which is what the doc comment promises.
+	if got := second.PrimaryKey["id"]; got != nil {
+		t.Errorf("reading a nil PrimaryKey should yield nil, got %v", got)
 	}
 }
 


### PR DESCRIPTION
## What

Adds `SpiceClient.Search(ctx, *SearchRequest)`, wrapping the runtime's `/v1/search` endpoint — vector similarity search, with optional `Keywords` for a hybrid lexical + vector ranking.

```go
limit := 3
resp, err := spice.Search(ctx, &gospice.SearchRequest{
    Text:              "tokyo plane tickets",
    Datasets:          []string{"app_messages"},
    Limit:             &limit,
    AdditionalColumns: []string{"timestamp"},
})
```

## Why

`/v1/search` works on a default `spice run`, but of the six client SDKs only spice.js could reach it. Go users had to hand-roll the HTTP call, including the response shape.

Part of aligning capabilities across the SDKs against the runtime's own API surface.

Two details the response types encode, taken from the runtime's wire format rather than the OpenAPI example (which is out of date on the first point):

- `Matches` holds a slice of values per column — one column can contribute several chunks to a single match.
- `data`, `primary_key`, and `metadata` are omitted by the runtime when empty, so each decodes to an empty map rather than being required.

Errors follow the pattern in `datasets.go` but also read the response body: the runtime explains search failures in plain text ("No data sources provided"), which a status code alone loses. Arguments the runtime would reject with a 400 — empty text, a `Limit` below 1 — are checked before the request so the error names the field to fix. An empty `Datasets` slice is omitted rather than sent, since the runtime 400s on an empty list.

## Verification

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` — clean
- [x] `go test -run TestSearch ./...` — 11 tests pass (6 top-level, 7 subtests), driven by `httptest` so they need no live runtime
- [ ] Full `go test ./...` — not run; the rest of the suite requires a live runtime (`spice run`) and a cloud API key

The new tests are runtime-free, so `TestSearch` is added to the `-run` allowlist the Windows-native unit test job uses. They also run in the full post-install suite on the other platforms.
